### PR TITLE
fix: extend search paths for app version on Linux systems

### DIFF
--- a/lib/others/about_us_version_resolver.dart
+++ b/lib/others/about_us_version_resolver.dart
@@ -57,6 +57,7 @@ Future<String> _loadLinuxBundleVersion({
   final candidatePaths = <String>[
     '${executableParent.path}/data/flutter_assets/version.json',
     '${executableParent.parent.path}/share/pslab/flutter_assets/version.json',
+    '/usr/share/pslab/flutter_assets/version.json',
   ];
 
   for (final candidatePath in candidatePaths) {

--- a/test/about_us_screen_version_test.dart
+++ b/test/about_us_screen_version_test.dart
@@ -56,4 +56,33 @@ void main() {
       expect(version, '9.8.7+45');
     },
   );
+
+  test('uses version in default path from package', () async {
+    final executablePath =
+        '${Platform.pathSeparator}usr${Platform.pathSeparator}bin${Platform.pathSeparator}'
+        'pslab';
+    final versionFile = File(
+      '${Platform.pathSeparator}usr${Platform.pathSeparator}bin${Platform.pathSeparator}'
+      'data${Platform.pathSeparator}flutter_assets${Platform.pathSeparator}'
+      'version.json',
+    );
+
+    IOOverrides.runZoned(() async {
+      await versionFile.create(recursive: true);
+      await versionFile.writeAsString('{"version":"6.5.3"}');
+
+      final version = await resolveAboutUsVersion(
+        packageInfoLoader: () async => PackageInfo(
+          appName: 'pslab',
+          packageName: 'io.pslab',
+          version: '',
+          buildNumber: '1234',
+        ),
+        isLinux: true,
+        resolvedExecutable: executablePath,
+      );
+
+      expect(version, '6.5.3+1234');
+    });
+  });
 }


### PR DESCRIPTION
Fixes #3398

## Changes
- added new element to array of paths which are used to search file which contains app version on Linux systems

## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Extend Linux app version resolution to search an additional shared installation path and cover it with tests.

Bug Fixes:
- Ensure the app can read its version from a shared /usr installation path on Linux when other locations are missing.

Tests:
- Add a test verifying that the Linux version resolver reads version.json from the default package path and combines it with the build number.