### PR TITLE
feat: add buffer overlay mode for oscilloscope

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -315,6 +315,7 @@
     "stackedMode": "Stacked mode",
     "stackedModeInfo": "Show each channel in its own vertical pane instead of overlapping on one plot.",
     "automatedMeasurements": "Automated Measurements",
+    "bufferOverlayMode": "Buffer overlay mode",
     "luxMeterTitle": "Lux Meter",
     "builtIn": "Built-In",
     "lx": "lx",

--- a/lib/models/oscilloscope_config.dart
+++ b/lib/models/oscilloscope_config.dart
@@ -1,27 +1,39 @@
 class OscilloscopeConfig {
   final bool includeLocationData;
+  final bool bufferOverlayEnabled;
+  final int bufferSize;
 
   const OscilloscopeConfig({
     this.includeLocationData = true,
+    this.bufferOverlayEnabled = false,
+    this.bufferSize = 5,
   });
 
   OscilloscopeConfig copyWith({
     bool? includeLocationData,
+    bool? bufferOverlayEnabled,
+    int? bufferSize,
   }) {
     return OscilloscopeConfig(
       includeLocationData: includeLocationData ?? this.includeLocationData,
+      bufferOverlayEnabled: bufferOverlayEnabled ?? this.bufferOverlayEnabled,
+      bufferSize: bufferSize ?? this.bufferSize,
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
       'includeLocationData': includeLocationData,
+      'bufferOverlayEnabled': bufferOverlayEnabled,
+      'bufferSize': bufferSize,
     };
   }
 
   factory OscilloscopeConfig.fromJson(Map<String, dynamic> json) {
     return OscilloscopeConfig(
       includeLocationData: json['includeLocationData'] ?? true,
+      bufferOverlayEnabled: json['bufferOverlayEnabled'] ?? false,
+      bufferSize: json['bufferSize'] ?? 5,
     );
   }
 }

--- a/lib/models/oscilloscope_config.dart
+++ b/lib/models/oscilloscope_config.dart
@@ -1,4 +1,6 @@
 class OscilloscopeConfig {
+  static const int defaultBufferSize = 5;
+
   final bool includeLocationData;
   final bool bufferOverlayEnabled;
   final int bufferSize;
@@ -6,7 +8,7 @@ class OscilloscopeConfig {
   const OscilloscopeConfig({
     this.includeLocationData = true,
     this.bufferOverlayEnabled = false,
-    this.bufferSize = 5,
+    this.bufferSize = defaultBufferSize,
   });
 
   OscilloscopeConfig copyWith({
@@ -33,7 +35,7 @@ class OscilloscopeConfig {
     return OscilloscopeConfig(
       includeLocationData: json['includeLocationData'] ?? true,
       bufferOverlayEnabled: json['bufferOverlayEnabled'] ?? false,
-      bufferSize: json['bufferSize'] ?? 5,
+      bufferSize: json['bufferSize'] ?? defaultBufferSize,
     );
   }
 }

--- a/lib/providers/oscilloscope_config_provider.dart
+++ b/lib/providers/oscilloscope_config_provider.dart
@@ -39,6 +39,18 @@ class OscilloscopeConfigProvider extends ChangeNotifier {
     _saveConfigToPrefs();
   }
 
+  void updateBufferOverlayEnabled(bool enabled) {
+    _config = _config.copyWith(bufferOverlayEnabled: enabled);
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void updateBufferSize(int size) {
+    _config = _config.copyWith(bufferSize: size);
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
   void resetToDefaults() {
     _config = const OscilloscopeConfig();
     notifyListeners();

--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -150,6 +150,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
   late String xyPlotAxis1;
   late String xyPlotAxis2;
   late List<List<FlSpot>> dataEntries;
+  final List<List<List<FlSpot>>> _waveformBuffer = [];
   late List<List<FlSpot>> dataEntriesXYPlot;
   late List<List<FlSpot>> dataEntriesCurveFit;
   late List<String> dataParamsChannels;
@@ -780,6 +781,17 @@ class OscilloscopeStateProvider extends ChangeNotifier {
         }
       }
 
+      if (_configProvider.config.bufferOverlayEnabled &&
+          dataEntries.isNotEmpty) {
+        _waveformBuffer.insert(0, dataEntries);
+        final maxSize = _configProvider.config.bufferSize;
+        if (_waveformBuffer.length > maxSize) {
+          _waveformBuffer.removeRange(maxSize, _waveformBuffer.length);
+        }
+      } else {
+        _waveformBuffer.clear();
+      }
+
       dataEntries = List.from(entries);
       dataEntriesCurveFit = List.from(curveFitEntries);
       dataParamsChannels = List.from(paramsChannels);
@@ -1265,6 +1277,27 @@ class OscilloscopeStateProvider extends ChangeNotifier {
   List<LineChartBarData> createPlots() {
     List<Color> curveFitColors = [Colors.yellow];
     List<LineChartBarData> plots = [];
+
+    if (_configProvider.config.bufferOverlayEnabled) {
+      for (int b = 0; b < _waveformBuffer.length; b++) {
+        final age = b + 1;
+        final opacity =
+            (1.0 - (age / (_waveformBuffer.length + 1))).clamp(0.1, 0.6);
+        plots.addAll(
+          List<LineChartBarData>.generate(
+            _waveformBuffer[b].length,
+            (index) => LineChartBarData(
+              spots: _waveformBuffer[b][index],
+              isCurved: true,
+              color: colors[index % colors.length].withValues(alpha: opacity),
+              barWidth: 1,
+              dotData: const FlDotData(show: false),
+            ),
+          ),
+        );
+      }
+    }
+
     plots.addAll(
       List<LineChartBarData>.generate(
         dataEntries.length,

--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -783,7 +783,10 @@ class OscilloscopeStateProvider extends ChangeNotifier {
 
       if (_configProvider.config.bufferOverlayEnabled &&
           dataEntries.isNotEmpty) {
-        _waveformBuffer.insert(0, dataEntries);
+        _waveformBuffer.insert(
+          0,
+          dataEntries.map((spots) => List<FlSpot>.from(spots)).toList(),
+        );
         final maxSize = _configProvider.config.bufferSize;
         if (_waveformBuffer.length > maxSize) {
           _waveformBuffer.removeRange(maxSize, _waveformBuffer.length);

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -117,6 +117,16 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
         ),
         PopupMenuItem<CheckboxListTile>(
           child: CheckboxListTile(
+            title: Text('Buffer overlay mode'),
+            value: _configProvider?.config.bufferOverlayEnabled ?? false,
+            onChanged: (bool? newValue) {
+              _configProvider?.updateBufferOverlayEnabled(newValue ?? false);
+              Navigator.pop(context);
+            },
+          ),
+        ),
+        PopupMenuItem<CheckboxListTile>(
+          child: CheckboxListTile(
             title: Text(appLocalizations.automatedMeasurements),
             secondary: IconButton(
                 icon: Icon(Icons.info_outline),

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -117,7 +117,7 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
         ),
         PopupMenuItem<CheckboxListTile>(
           child: CheckboxListTile(
-            title: Text('Buffer overlay mode'),
+            title: Text(appLocalizations.bufferOverlayMode),
             value: _configProvider?.config.bufferOverlayEnabled ?? false,
             onChanged: (bool? newValue) {
               _configProvider?.updateBufferOverlayEnabled(newValue ?? false);


### PR DESCRIPTION
Fixes #3464

## Changes
- Added `bufferOverlayEnabled` and `bufferSize` fields to `OscilloscopeConfig`, persisted via `SharedPreferences`
- Added `updateBufferOverlayEnabled()` and `updateBufferSize()` methods to `OscilloscopeConfigProvider`
- `OscilloscopeStateProvider` now keeps a rolling buffer of the last N acquired waveforms when buffer overlay mode is enabled, instead of discarding the previous frame on every new acquisition
- `createPlots()` renders buffered (older) waveforms behind the current live waveform, with opacity fading based on age — newer frames are more visible, older ones fade out
- Added a "Buffer overlay mode" toggle to the oscilloscope's options menu (⋮), next to "Automated measurements"

## Screenshots / Recordings
**Buffer overlay OFF** (default/current behavior — only the live waveform is shown):

https://github.com/user-attachments/assets/9d4a6395-d2a2-4220-988c-37aefd3a5d7b



**Buffer overlay ON** (previous waveform(s) remain visible, fading behind the new one):

Uploading buffer overlay on - Trim.mp4…





## Notes for reviewers
- Buffer size currently defaults to a fixed value with no UI slider to change it yet. Happy to add a configurable size control (e.g. a slider in Oscilloscope Configurations) as a follow-up if that's preferred, or in this same PR if you'd like it now — let me know.
- Tested manually using the in-built microphone as a signal source (no physical PSLab hardware available during development).

**Checklist**:
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

Uploading buffer overlay on - Trim.mp4…

