### PR TITLE
fix: limit save filename dialog max width

### DIFF
--- a/lib/view/widgets/save_filename_dialog.dart
+++ b/lib/view/widgets/save_filename_dialog.dart
@@ -93,123 +93,128 @@ class _AdaptiveSaveDialogState extends State<_AdaptiveSaveDialog> {
           ? const EdgeInsets.only(
               top: 24.0, left: 32.0, right: 32.0, bottom: 8.0)
           : const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
-      child: SingleChildScrollView(
-        child: Padding(
-          padding: isLandscape
-              ? const EdgeInsets.fromLTRB(16.0, 12.0, 16.0, 10.0)
-              : const EdgeInsets.fromLTRB(24.0, 24.0, 24.0, 16.0),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                widget.customTitle ?? appLocalizations.saveRecording,
-                style: TextStyle(
-                  fontWeight: FontWeight.w600,
-                  fontSize: titleFontSize,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(
+          maxWidth: 450,
+        ),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: isLandscape
+                ? const EdgeInsets.fromLTRB(16.0, 12.0, 16.0, 10.0)
+                : const EdgeInsets.fromLTRB(24.0, 24.0, 24.0, 16.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  widget.customTitle ?? appLocalizations.saveRecording,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    fontSize: titleFontSize,
+                  ),
                 ),
-              ),
-              SizedBox(height: isLandscape ? 8 : 16),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: TextField(
-                      controller: _controller,
-                      autofocus: true,
-                      maxLength: kMaxFileNameLength,
-                      cursorColor: primaryRed,
-                      style: TextStyle(fontSize: inputFontSize),
-                      decoration: InputDecoration(
-                        hintText: appLocalizations.enterFileName,
-                        labelText: appLocalizations.fileName,
-                        floatingLabelStyle: TextStyle(color: primaryRed),
-                        counterText: '',
-                        isDense: true,
-                        border: defaultBorder,
-                        enabledBorder: defaultBorder,
-                        focusedBorder: focusedBorder,
-                        contentPadding: inputPadding,
+                SizedBox(height: isLandscape ? 8 : 16),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        controller: _controller,
+                        autofocus: true,
+                        maxLength: kMaxFileNameLength,
+                        cursorColor: primaryRed,
+                        style: TextStyle(fontSize: inputFontSize),
+                        decoration: InputDecoration(
+                          hintText: appLocalizations.enterFileName,
+                          labelText: appLocalizations.fileName,
+                          floatingLabelStyle: TextStyle(color: primaryRed),
+                          counterText: '',
+                          isDense: true,
+                          border: defaultBorder,
+                          enabledBorder: defaultBorder,
+                          focusedBorder: focusedBorder,
+                          contentPadding: inputPadding,
+                        ),
                       ),
                     ),
-                  ),
-                  const SizedBox(width: 8),
-                  SizedBox(
-                    width: isLandscape ? 80 : 90,
-                    child: DropdownButtonFormField<String>(
-                      initialValue: _selectedFormat,
-                      iconEnabledColor: primaryRed,
-                      style: TextStyle(
-                          fontSize: inputFontSize, color: Colors.black),
-                      decoration: InputDecoration(
-                        isDense: true,
-                        border: defaultBorder,
-                        enabledBorder: defaultBorder,
-                        focusedBorder: focusedBorder,
-                        contentPadding: inputPadding,
+                    const SizedBox(width: 8),
+                    SizedBox(
+                      width: isLandscape ? 80 : 90,
+                      child: DropdownButtonFormField<String>(
+                        initialValue: _selectedFormat,
+                        iconEnabledColor: primaryRed,
+                        style: TextStyle(
+                            fontSize: inputFontSize, color: Colors.black),
+                        decoration: InputDecoration(
+                          isDense: true,
+                          border: defaultBorder,
+                          enabledBorder: defaultBorder,
+                          focusedBorder: focusedBorder,
+                          contentPadding: inputPadding,
+                        ),
+                        items: const [
+                          DropdownMenuItem(value: 'CSV', child: Text('.csv')),
+                          DropdownMenuItem(value: 'TXT', child: Text('.txt')),
+                          DropdownMenuItem(value: 'JSON', child: Text('.json')),
+                        ],
+                        onChanged: (val) {
+                          if (val != null) {
+                            setState(() {
+                              _selectedFormat = val;
+                            });
+                          }
+                        },
                       ),
-                      items: const [
-                        DropdownMenuItem(value: 'CSV', child: Text('.csv')),
-                        DropdownMenuItem(value: 'TXT', child: Text('.txt')),
-                        DropdownMenuItem(value: 'JSON', child: Text('.json')),
-                      ],
-                      onChanged: (val) {
-                        if (val != null) {
-                          setState(() {
-                            _selectedFormat = val;
-                          });
-                        }
+                    ),
+                  ],
+                ),
+                if (widget.extraWidgets != null) ...[
+                  SizedBox(height: isLandscape ? 6 : 12),
+                  ...widget.extraWidgets!,
+                ],
+                SizedBox(height: isLandscape ? 12 : 24),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton(
+                      style: TextButton.styleFrom(
+                        foregroundColor: primaryRed,
+                        visualDensity: isLandscape
+                            ? VisualDensity.compact
+                            : VisualDensity.standard,
+                        textStyle: TextStyle(fontSize: buttonFontSize),
+                      ),
+                      onPressed: () => Navigator.pop(context),
+                      child: Text(appLocalizations.cancel.toUpperCase()),
+                    ),
+                    const SizedBox(width: 8),
+                    ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: primaryRed,
+                        foregroundColor: Colors.white,
+                        elevation: 0,
+                        visualDensity: isLandscape
+                            ? VisualDensity.compact
+                            : VisualDensity.standard,
+                        textStyle: TextStyle(fontSize: buttonFontSize),
+                        padding: isLandscape
+                            ? const EdgeInsets.symmetric(
+                                horizontal: 16, vertical: 6)
+                            : const EdgeInsets.symmetric(
+                                horizontal: 24, vertical: 10),
+                      ),
+                      onPressed: () {
+                        Navigator.pop(
+                            context,
+                            SaveDialogResult(
+                                _controller.text.trim(), _selectedFormat));
                       },
+                      child: Text(appLocalizations.save),
                     ),
-                  ),
-                ],
-              ),
-              if (widget.extraWidgets != null) ...[
-                SizedBox(height: isLandscape ? 6 : 12),
-                ...widget.extraWidgets!,
+                  ],
+                ),
               ],
-              SizedBox(height: isLandscape ? 12 : 24),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  TextButton(
-                    style: TextButton.styleFrom(
-                      foregroundColor: primaryRed,
-                      visualDensity: isLandscape
-                          ? VisualDensity.compact
-                          : VisualDensity.standard,
-                      textStyle: TextStyle(fontSize: buttonFontSize),
-                    ),
-                    onPressed: () => Navigator.pop(context),
-                    child: Text(appLocalizations.cancel.toUpperCase()),
-                  ),
-                  const SizedBox(width: 8),
-                  ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: primaryRed,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
-                      visualDensity: isLandscape
-                          ? VisualDensity.compact
-                          : VisualDensity.standard,
-                      textStyle: TextStyle(fontSize: buttonFontSize),
-                      padding: isLandscape
-                          ? const EdgeInsets.symmetric(
-                              horizontal: 16, vertical: 6)
-                          : const EdgeInsets.symmetric(
-                              horizontal: 24, vertical: 10),
-                    ),
-                    onPressed: () {
-                      Navigator.pop(
-                          context,
-                          SaveDialogResult(
-                              _controller.text.trim(), _selectedFormat));
-                    },
-                    child: Text(appLocalizations.save),
-                  ),
-                ],
-              ),
-            ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Fixes #3450

## Changes
limit save filename dialog max width

## Screenshots / Recordings
android:
<img width="2400" height="1080" alt="Screenshot_20260804-142632 PSLab" src="https://github.com/user-attachments/assets/e65a7284-16f2-42bd-9fe6-ef071e826f87" />

desktop:

https://github.com/user-attachments/assets/b2162785-853d-4ea3-8894-c01df2213a8c



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [ ] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [ ] **No end of file edits**: No modifications done at end of resource files.
- [ ] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [ ] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Enhancements:
- Add a max-width constraint to the save filename dialog to prevent it from stretching excessively on wide displays.