### PR TITLE
fix: improve oscilloscope graph scaling and channel controls

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -877,5 +877,6 @@
     "frequencySpread": "FREQUENCY SPREAD",
     "low": "Low",
     "mid": "Mid",
-    "high": "High"
+    "high": "High",
+    "rangeScale" : "Range :"
 }

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -41,11 +41,7 @@ class OscilloscopeScreen extends StatefulWidget {
 }
 
 class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
-  /// Approx. content height for the bottom controls (two rows of
-  /// checkbox + dropdown). Same for Channel / Timebase / Data Analysis / XY
-  /// Plot. Not true wrap-content yet: those tabs use Stack + Positioned, so
-  /// they need an explicit height (see fossasia/pslab-app#3461 / #3468).
-  static const double _controlsContentHeight = 120;
+  static const double _controlsContentHeight = 95;
 
   late OscilloscopeStateProvider _provider;
   late OscilloscopeConfigProvider? _configProvider;
@@ -413,10 +409,9 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
                                         child: Container(
                                           margin:
                                               const EdgeInsets.only(right: 5),
-                                          padding:
-                                              const EdgeInsets.only(bottom: 20),
+                                          padding: EdgeInsets.zero,
                                           color: Colors.black,
-                                          child: OscilloscopeGraph(),
+                                          child: const OscilloscopeGraph(),
                                         ),
                                       ),
                                       _PlaybackControlBar(
@@ -452,17 +447,13 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
                                                 children: [
                                                   Expanded(
                                                     child: Container(
-                                                      padding:
-                                                          const EdgeInsets.only(
-                                                              bottom: 20),
+                                                      padding: EdgeInsets.zero,
                                                       color: Colors.black,
                                                       child:
                                                           const OscilloscopeGraph(),
                                                     ),
                                                   ),
                                                   SizedBox(
-                                                    // Cap so phones keep most of
-                                                    // the screen for the graph.
                                                     height:
                                                         _controlsContentHeight
                                                             .clamp(

--- a/lib/view/widgets/channel_parameters_widget.dart
+++ b/lib/view/widgets/channel_parameters_widget.dart
@@ -34,13 +34,92 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
     ];
   }
 
+  Widget _buildChannelRow(
+      String title, bool isSelected, Function(bool?) onChanged,
+      [String? staticRange]) {
+    return SizedBox(
+      height: 36,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Transform.scale(
+            scale: 0.9,
+            child: Checkbox(
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+              activeColor: checkBoxActiveColor,
+              value: isSelected,
+              onChanged: onChanged,
+            ),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            staticRange != null && staticRange.isNotEmpty
+                ? '$title ($staticRange)'
+                : title,
+            style: TextStyle(
+              color: oscilloscopeOptionLabelColor,
+              fontSize: 14.0,
+              fontWeight: FontWeight.bold,
+              fontStyle: FontStyle.normal,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMicRadio(
+      String title, bool isSelected, Function(bool?) onChanged) {
+    return SizedBox(
+      height: 36,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Transform.scale(
+            scale: 0.9,
+            child: RadioGroup<bool>(
+              groupValue: isSelected,
+              onChanged: onChanged,
+              child: Radio<bool>(
+                activeColor: radioButtonActiveColor,
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                visualDensity:
+                    const VisualDensity(horizontal: -4, vertical: -4),
+                value: true,
+                toggleable: true,
+              ),
+            ),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            title,
+            style: TextStyle(
+              color: oscilloscopeOptionLabelColor,
+              fontSize: 14.0,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     OscilloscopeStateProvider oscilloscopeStateProvider =
         Provider.of<OscilloscopeStateProvider>(context, listen: false);
+
+    String currentGlobalRange =
+        yAxisRanges[oscilloscopeStateProvider.oscillscopeRangeSelection];
+
     return Stack(
       children: [
         Container(
+          height: 90,
+          width: double.infinity,
           margin: const EdgeInsets.only(top: 8, bottom: 5),
           decoration: BoxDecoration(
             border: Border.all(width: 1, color: primaryRed),
@@ -49,293 +128,182 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
           child: Stack(
             children: [
               Positioned(
-                top: -4,
-                left: 4,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Checkbox(
-                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      value: oscilloscopeStateProvider.isCH1Selected,
-                      activeColor: checkBoxActiveColor,
-                      onChanged: (bool? value) {
-                        setState(() {
-                          oscilloscopeStateProvider.setChannelSelected(
-                              'CH1', value ?? false);
-                        });
-                      },
-                    ),
-                    Text(
-                      appLocalizations.ch1,
-                      style: TextStyle(
-                        color: oscilloscopeOptionLabelColor,
-                        fontWeight: FontWeight.bold,
-                        fontStyle: FontStyle.normal,
-                        fontSize: 14.5,
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(left: 8),
-                      child: Text(
-                        appLocalizations.range,
-                        style: const TextStyle(
-                          color: Color(0xFF424242),
-                          fontWeight: FontWeight.normal,
-                          fontStyle: FontStyle.normal,
-                          fontSize: 14.5,
-                        ),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(left: 8),
-                      child: DropdownMenu<String>(
-                        initialSelection: yAxisRanges[oscilloscopeStateProvider
-                            .oscillscopeRangeSelection],
-                        width: 140,
-                        dropdownMenuEntries: yAxisRanges.map(
-                          (String value) {
-                            return DropdownMenuEntry<String>(
-                              label: value,
-                              value: value,
-                            );
-                          },
-                        ).toList(),
-                        inputDecorationTheme: const InputDecorationTheme(
-                          border: InputBorder.none,
-                        ),
-                        textStyle: TextStyle(
-                            color: oscilloscopeOptionLabelColor,
-                            fontSize: 14.5),
-                        onSelected: (String? value) {
-                          switch (yAxisRanges.indexOf(value!)) {
-                            case 0:
-                              oscilloscopeStateProvider.setYAxisScale(16);
-                              break;
-                            case 1:
-                              oscilloscopeStateProvider.setYAxisScale(8);
-                              break;
-                            case 2:
-                              oscilloscopeStateProvider.setYAxisScale(4);
-                              break;
-                            case 3:
-                              oscilloscopeStateProvider.setYAxisScale(3);
-                              break;
-                            case 4:
-                              oscilloscopeStateProvider.setYAxisScale(2);
-                              break;
-                            case 5:
-                              oscilloscopeStateProvider.setYAxisScale(1.5);
-                              break;
-                            case 6:
-                              oscilloscopeStateProvider.setYAxisScale(1);
-                              break;
-                            case 7:
-                              oscilloscopeStateProvider.setYAxisScale(0.5);
-                              break;
-                            case 8:
-                              oscilloscopeStateProvider.setYAxisScale(160);
-                              break;
-                            default:
-                              oscilloscopeStateProvider.setYAxisScale(16);
-                              break;
-                          }
-                          oscilloscopeStateProvider.oscillscopeRangeSelection =
-                              yAxisRanges.indexOf(value);
-                        },
-                      ),
-                    ),
-                  ],
+                top: 4,
+                left: 8,
+                child: _buildChannelRow(
+                  appLocalizations.ch1,
+                  oscilloscopeStateProvider.isCH1Selected,
+                  (value) => setState(() => oscilloscopeStateProvider
+                      .setChannelSelected('CH1', value ?? false)),
+                  '+/- 16V',
                 ),
               ),
               Positioned(
-                left: 4,
-                bottom: 2,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Checkbox(
-                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      value: oscilloscopeStateProvider.isCH2Selected,
-                      activeColor: checkBoxActiveColor,
-                      onChanged: (bool? value) {
-                        setState(() {
-                          oscilloscopeStateProvider.setChannelSelected(
-                              'CH2', value ?? false);
-                        });
-                      },
-                    ),
-                    Text(
-                      appLocalizations.ch2,
-                      style: TextStyle(
-                        color: oscilloscopeOptionLabelColor,
-                        fontWeight: FontWeight.bold,
-                        fontStyle: FontStyle.normal,
-                        fontSize: 14.5,
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(left: 8),
-                      child: Text(
-                        appLocalizations.range,
-                        style: const TextStyle(
-                          color: Color(0xFF424242),
-                          fontWeight: FontWeight.normal,
-                          fontStyle: FontStyle.normal,
-                          fontSize: 14.5,
-                        ),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(left: 8),
-                      child: SizedBox(
-                        width: 120,
-                        child: Text(
-                          appLocalizations.rangeValue,
-                          style: TextStyle(
-                            color: oscilloscopeOptionLabelColor,
-                            fontStyle: FontStyle.normal,
-                            fontWeight: FontWeight.normal,
-                            fontSize: 14.5,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
+                bottom: 4,
+                left: 8,
+                child: _buildChannelRow(
+                  appLocalizations.ch2,
+                  oscilloscopeStateProvider.isCH2Selected,
+                  (value) => setState(() => oscilloscopeStateProvider
+                      .setChannelSelected('CH2', value ?? false)),
+                  '+/- 16V',
                 ),
               ),
               Positioned(
                 top: 4,
-                right: 8,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Checkbox(
-                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      value: oscilloscopeStateProvider.isCH3Selected,
-                      activeColor: checkBoxActiveColor,
-                      onChanged: (bool? value) {
-                        setState(() {
-                          oscilloscopeStateProvider.setChannelSelected(
-                              'CH3', value ?? false);
-                        });
-                      },
-                    ),
-                    Text(
-                      appLocalizations.ch3Range,
-                      style: TextStyle(
-                        color: oscilloscopeOptionLabelColor,
-                        fontWeight: FontWeight.bold,
-                        fontStyle: FontStyle.normal,
-                        fontSize: 14.5,
-                      ),
-                    ),
-                  ],
+                left: 165,
+                child: _buildChannelRow(
+                  "CH3",
+                  oscilloscopeStateProvider.isCH3Selected,
+                  (value) => setState(() => oscilloscopeStateProvider
+                      .setChannelSelected('CH3', value ?? false)),
+                  '+/- 3.3V',
                 ),
               ),
               Positioned(
-                bottom: 2,
+                bottom: 4,
+                left: 168,
+                child: SizedBox(
+                  height: 36,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Text(
+                        appLocalizations.rangeScale,
+                        style: TextStyle(
+                          color: Colors.black,
+                          fontSize: 14.0,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Transform.translate(
+                        offset: const Offset(0, -8),
+                        child: DropdownMenu<String>(
+                          width: 135,
+                          initialSelection: currentGlobalRange,
+                          dropdownMenuEntries: yAxisRanges.map((String value) {
+                            return DropdownMenuEntry<String>(
+                              label: value,
+                              value: value,
+                            );
+                          }).toList(),
+                          inputDecorationTheme: const InputDecorationTheme(
+                            border: InputBorder.none,
+                            isDense: true,
+                            contentPadding: EdgeInsets.zero,
+                          ),
+                          textStyle: TextStyle(
+                            color: oscilloscopeOptionLabelColor,
+                            fontSize: 13.5,
+                            fontWeight: FontWeight.bold,
+                          ),
+                          onSelected: (String? value) {
+                            if (value == null) return;
+                            int index = yAxisRanges.indexOf(value);
+                            setState(() {
+                              oscilloscopeStateProvider
+                                  .oscillscopeRangeSelection = index;
+                              switch (index) {
+                                case 0:
+                                  oscilloscopeStateProvider.setYAxisScale(16);
+                                  break;
+                                case 1:
+                                  oscilloscopeStateProvider.setYAxisScale(8);
+                                  break;
+                                case 2:
+                                  oscilloscopeStateProvider.setYAxisScale(4);
+                                  break;
+                                case 3:
+                                  oscilloscopeStateProvider.setYAxisScale(3);
+                                  break;
+                                case 4:
+                                  oscilloscopeStateProvider.setYAxisScale(2);
+                                  break;
+                                case 5:
+                                  oscilloscopeStateProvider.setYAxisScale(1.5);
+                                  break;
+                                case 6:
+                                  oscilloscopeStateProvider.setYAxisScale(1);
+                                  break;
+                                case 7:
+                                  oscilloscopeStateProvider.setYAxisScale(0.5);
+                                  break;
+                                case 8:
+                                  oscilloscopeStateProvider.setYAxisScale(160);
+                                  break;
+                                default:
+                                  oscilloscopeStateProvider.setYAxisScale(16);
+                                  break;
+                              }
+                            });
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Positioned(
+                top: 4,
+                bottom: 4,
                 right: 8,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.center,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    RadioGroup(
-                      groupValue:
-                          oscilloscopeStateProvider.isInBuiltMICSelected,
-                      onChanged: (bool? value) async {
+                    _buildMicRadio(
+                      appLocalizations.inBuiltMic,
+                      oscilloscopeStateProvider.isInBuiltMICSelected,
+                      (value) async {
                         if (value == true) {
                           final AppPermissionStatus status =
                               await PSLabPermissions.request(
                                   AppPermission.microphone);
-
                           if (status != AppPermissionStatus.granted) {
-                            logger.e(
-                                "Microphone permission was denied or permanently blocked.");
+                            logger.e("Microphone permission was denied.");
                             return;
                           }
                         }
-                        setState(
-                          () {
-                            if (value == null) {
-                              oscilloscopeStateProvider.isInBuiltMICSelected =
-                                  false;
-                              oscilloscopeStateProvider.isAudioInputSelected =
-                                  false;
-                              oscilloscopeStateProvider.setTimebaseDivisions(8);
-                              oscilloscopeStateProvider
-                                  .removeChannelData('MIC');
-                            } else {
-                              if (value == true) {
-                                oscilloscopeStateProvider
-                                    .setTimebaseDivisions(6);
-                              } else {
-                                oscilloscopeStateProvider
-                                    .setTimebaseDivisions(8);
-                              }
-                              oscilloscopeStateProvider.isAudioInputSelected =
-                                  true;
-                              oscilloscopeStateProvider.isInBuiltMICSelected =
-                                  value;
-                              oscilloscopeStateProvider.isMICSelected = !value;
-                            }
-                          },
-                        );
+                        setState(() {
+                          if (value == null || !value) {
+                            oscilloscopeStateProvider.isInBuiltMICSelected =
+                                false;
+                            oscilloscopeStateProvider.isAudioInputSelected =
+                                false;
+                            oscilloscopeStateProvider.setTimebaseDivisions(8);
+                            oscilloscopeStateProvider.removeChannelData('MIC');
+                          } else {
+                            oscilloscopeStateProvider.setTimebaseDivisions(6);
+                            oscilloscopeStateProvider.isAudioInputSelected =
+                                true;
+                            oscilloscopeStateProvider.isInBuiltMICSelected =
+                                true;
+                            oscilloscopeStateProvider.isMICSelected = false;
+                          }
+                        });
                       },
-                      child: Radio<bool>(
-                        activeColor: radioButtonActiveColor,
-                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                        value: true,
-                        toggleable: true,
-                      ),
                     ),
-                    Text(
-                      appLocalizations.inBuiltMic,
-                      style: TextStyle(
-                        color: oscilloscopeOptionLabelColor,
-                        fontSize: 14.5,
-                        fontWeight: FontWeight.bold,
-                        fontStyle: FontStyle.normal,
-                      ),
-                    ),
-                    RadioGroup(
-                      groupValue: oscilloscopeStateProvider.isMICSelected,
-                      onChanged: (bool? value) {
-                        setState(
-                          () {
-                            if (value == null) {
-                              oscilloscopeStateProvider.isMICSelected = false;
-                              oscilloscopeStateProvider.isAudioInputSelected =
-                                  false;
-                              oscilloscopeStateProvider
-                                  .removeChannelData('MIC');
-                            } else {
-                              oscilloscopeStateProvider.isAudioInputSelected =
-                                  true;
-                              oscilloscopeStateProvider.isMICSelected = value;
-                              oscilloscopeStateProvider.isInBuiltMICSelected =
-                                  !value;
-                            }
-                          },
-                        );
-                      },
-                      child: Radio<bool>(
-                        activeColor: radioButtonActiveColor,
-                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                        value: true,
-                        toggleable: true,
-                      ),
-                    ),
-                    Text(
+                    _buildMicRadio(
                       appLocalizations.pslabMic,
-                      style: TextStyle(
-                        color: oscilloscopeOptionLabelColor,
-                        fontSize: 14.5,
-                        fontWeight: FontWeight.bold,
-                        fontStyle: FontStyle.normal,
-                      ),
+                      oscilloscopeStateProvider.isMICSelected,
+                      (value) {
+                        setState(() {
+                          if (value == null || !value) {
+                            oscilloscopeStateProvider.isMICSelected = false;
+                            oscilloscopeStateProvider.isAudioInputSelected =
+                                false;
+                            oscilloscopeStateProvider.removeChannelData('MIC');
+                          } else {
+                            oscilloscopeStateProvider.isAudioInputSelected =
+                                true;
+                            oscilloscopeStateProvider.isMICSelected = true;
+                            oscilloscopeStateProvider.isInBuiltMICSelected =
+                                false;
+                          }
+                        });
+                      },
                     ),
                   ],
                 ),
@@ -350,15 +318,14 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
           child: Align(
             alignment: Alignment.center,
             child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 2),
+              padding: const EdgeInsets.symmetric(horizontal: 4),
               decoration: BoxDecoration(color: oscilloscopeOptionTitleBoxColor),
               child: Text(
                 appLocalizations.channels,
                 style: TextStyle(
                   color: oscilloscopeOptionTitleColor,
-                  fontStyle: FontStyle.normal,
                   fontWeight: FontWeight.bold,
-                  fontSize: 13,
+                  fontSize: 12,
                 ),
               ),
             ),

--- a/lib/view/widgets/oscilloscope_graph.dart
+++ b/lib/view/widgets/oscilloscope_graph.dart
@@ -14,6 +14,13 @@ class OscilloscopeGraph extends StatefulWidget {
 }
 
 class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
+  final List<Color> plotColors = [
+    Colors.cyan,
+    Colors.green,
+    Colors.white,
+    Colors.purpleAccent
+  ];
+
   Widget sideTitleWidgets(double value, TitleMeta meta) {
     final style = TextStyle(
       color: chartTextColor,
@@ -50,115 +57,168 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
         : provider.oscilloscopeAxesScale.xAxisScale / 1000;
   }
 
+  Widget _buildLegend(OscilloscopeStateProvider provider) {
+    if (provider.dataParamsChannels.isEmpty) return const SizedBox.shrink();
+
+    return Wrap(
+      spacing: 16.0,
+      runSpacing: 4.0,
+      alignment: WrapAlignment.end,
+      children: List.generate(provider.dataParamsChannels.length, (index) {
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 14,
+              height: 3,
+              color: plotColors[index % plotColors.length],
+            ),
+            const SizedBox(width: 8),
+            Text(
+              provider.dataParamsChannels[index],
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 12,
+              ),
+            ),
+          ],
+        );
+      }),
+    );
+  }
+
   Widget _buildOverlayChart(OscilloscopeStateProvider provider) {
-    return LineChart(
-      LineChartData(
-        backgroundColor: chartBackgroundColor,
-        lineTouchData: LineTouchData(
-          enabled: !provider.isPlayingBack,
-        ),
-        titlesData: FlTitlesData(
-          show: true,
-          topTitles: AxisTitles(
-            axisNameWidget: Text(
-              provider.isFourierTransformSelected
-                  ? 'Frequency (Hz)'
-                  : (provider.oscilloscopeAxesScale.xAxisScale == 875
-                      ? 'Time (\u00b5s)'
-                      : 'Time (ms)'),
-              style: TextStyle(
-                fontSize: 10,
-                color: chartTextColor,
-                fontWeight: FontWeight.bold,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(
+          child: LineChart(
+            LineChartData(
+              backgroundColor: chartBackgroundColor,
+              lineTouchData: LineTouchData(
+                enabled: !provider.isPlayingBack,
               ),
-            ),
-            sideTitles: SideTitles(
-              maxIncluded: false,
-              interval: provider.oscilloscopeAxesScale.getTimebaseInterval(),
-              reservedSize: 20,
-              showTitles: true,
-              getTitlesWidget: topTitleWidgets,
-            ),
-          ),
-          bottomTitles:
-              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-          leftTitles: AxisTitles(
-            axisNameWidget: Text(
-              provider.isFourierTransformSelected ? 'Magnitude (V)' : 'CH1 (V)',
-              style: TextStyle(
-                fontSize: 10,
-                color: chartTextColor,
-                fontWeight: FontWeight.bold,
+              titlesData: FlTitlesData(
+                show: true,
+                topTitles: AxisTitles(
+                  axisNameWidget: Text(
+                    provider.isFourierTransformSelected
+                        ? 'Frequency (Hz)'
+                        : (provider.oscilloscopeAxesScale.xAxisScale == 875
+                            ? 'Time (\u00b5s)'
+                            : 'Time (ms)'),
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: chartTextColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  sideTitles: SideTitles(
+                    maxIncluded: false,
+                    interval:
+                        provider.oscilloscopeAxesScale.getTimebaseInterval(),
+                    reservedSize: 20,
+                    showTitles: true,
+                    getTitlesWidget: topTitleWidgets,
+                  ),
+                ),
+                bottomTitles:
+                    const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                leftTitles: AxisTitles(
+                  axisNameWidget: Text(
+                    provider.isFourierTransformSelected
+                        ? 'Magnitude (V)'
+                        : '(V)',
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: chartTextColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  sideTitles: SideTitles(
+                    interval: provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
+                    reservedSize: 30,
+                    showTitles: true,
+                    getTitlesWidget: sideTitleWidgets,
+                  ),
+                ),
+                rightTitles: AxisTitles(
+                  axisNameWidget: Text(
+                    provider.isFourierTransformSelected
+                        ? 'Magnitude (V)'
+                        : '(V)',
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: chartTextColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  sideTitles: SideTitles(
+                    interval: provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
+                    reservedSize: 30,
+                    showTitles: true,
+                    getTitlesWidget: sideTitleWidgets,
+                  ),
+                ),
               ),
-            ),
-            sideTitles: SideTitles(
-              interval: provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
-              reservedSize: 30,
-              showTitles: true,
-              getTitlesWidget: sideTitleWidgets,
-            ),
-          ),
-          rightTitles: AxisTitles(
-            axisNameWidget: Text(
-              provider.isFourierTransformSelected ? 'Magnitude (V)' : 'CH2 (V)',
-              style: TextStyle(
-                fontSize: 10,
-                color: chartTextColor,
-                fontWeight: FontWeight.bold,
+              gridData: FlGridData(
+                show: true,
+                drawHorizontalLine: true,
+                drawVerticalLine: true,
+                horizontalInterval:
+                    provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
+                verticalInterval:
+                    provider.oscilloscopeAxesScale.getTimebaseInterval(),
+                getDrawingHorizontalLine: (value) {
+                  return const FlLine(
+                    color: Color.fromARGB(50, 255, 255, 255),
+                    strokeWidth: 1,
+                  );
+                },
+                getDrawingVerticalLine: (value) {
+                  return const FlLine(
+                    color: Color.fromARGB(50, 255, 255, 255),
+                    strokeWidth: 1,
+                  );
+                },
               ),
-            ),
-            sideTitles: SideTitles(
-              interval: provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
-              reservedSize: 30,
-              showTitles: true,
-              getTitlesWidget: sideTitleWidgets,
-            ),
-          ),
-        ),
-        gridData: FlGridData(
-          show: true,
-          drawHorizontalLine: true,
-          drawVerticalLine: true,
-          horizontalInterval: provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
-          verticalInterval:
-              provider.oscilloscopeAxesScale.getTimebaseInterval(),
-          getDrawingHorizontalLine: (value) {
-            return const FlLine(
-              color: Color.fromARGB(50, 255, 255, 255),
-              strokeWidth: 1,
-            );
-          },
-          getDrawingVerticalLine: (value) {
-            return const FlLine(
-              color: Color.fromARGB(50, 255, 255, 255),
-              strokeWidth: 1,
-            );
-          },
-        ),
-        borderData: FlBorderData(
-          show: true,
-          border: Border(
-            bottom: BorderSide(
-              color: chartBorderColor,
-            ),
-            left: BorderSide(
-              color: chartBorderColor,
-            ),
-            top: BorderSide(
-              color: chartBorderColor,
-            ),
-            right: BorderSide(
-              color: chartBorderColor,
+              borderData: FlBorderData(
+                show: true,
+                border: Border(
+                  bottom: BorderSide(
+                    color: chartBorderColor,
+                  ),
+                  left: BorderSide(
+                    color: chartBorderColor,
+                  ),
+                  top: BorderSide(
+                    color: chartBorderColor,
+                  ),
+                  right: BorderSide(
+                    color: chartBorderColor,
+                  ),
+                ),
+              ),
+              maxY: provider.oscilloscopeAxesScale.yAxisScaleMax,
+              minY: provider.oscilloscopeAxesScale.yAxisScaleMin,
+              maxX: _maxX(provider),
+              minX: 0,
+              clipData: const FlClipData.all(),
+              lineBarsData: provider.createPlots(),
             ),
           ),
         ),
-        maxY: provider.oscilloscopeAxesScale.yAxisScaleMax,
-        minY: provider.oscilloscopeAxesScale.yAxisScaleMin,
-        maxX: _maxX(provider),
-        minX: 0,
-        clipData: const FlClipData.all(),
-        lineBarsData: provider.createPlots(),
-      ),
+        SizedBox(
+          height: 24,
+          child: Padding(
+            padding: const EdgeInsets.only(top: 4.0, right: 35.0),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: _buildLegend(provider),
+            ),
+          ),
+        ),
+      ],
     );
   }
 
@@ -284,6 +344,16 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
               ),
             ),
           ),
+        SizedBox(
+          height: 24,
+          child: Padding(
+            padding: const EdgeInsets.only(top: 4.0, right: 35.0),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: _buildLegend(provider),
+            ),
+          ),
+        ),
       ],
     );
   }
@@ -299,10 +369,14 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
         }
         if (provider.isStackedMode) {
           return SizedBox(
+            width: double.infinity,
+            height: double.infinity,
             child: _buildStackedCharts(provider),
           );
         }
         return SizedBox(
+          width: double.infinity,
+          height: double.infinity,
           child: _buildOverlayChart(provider),
         );
       },


### PR DESCRIPTION
Fixes #3473

## Changes
- Refactored the channel parameter UI for improved responsiveness.
- Added a global `Range` option that scales all channels simultaneously, reducing user confusion.
- Added a color-coded legend at the bottom of the graph for active channels.

## Screenshots / Recordings
<img width="1917" height="976" alt="Screenshot 2026-08-05 164313" src="https://github.com/user-attachments/assets/6dfa14ce-b580-450a-9c93-74d20d0e073b" />


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Improve oscilloscope channel controls and graph readability, including unified range scaling and a color‑coded legend.

Enhancements:
- Refine channel parameter layout with reusable widgets and compact sizing for better responsiveness.
- Introduce a single global vertical range selector that adjusts all oscilloscope channels together.
- Update oscilloscope graph layout to fill available space and add a color‑coded legend for active channels.