### PR TITLE
fix: prevent horizontal overflow in Timeline controls of robotic arms

### DIFF
--- a/lib/view/widgets/robotic_arm_controls.dart
+++ b/lib/view/widgets/robotic_arm_controls.dart
@@ -266,8 +266,6 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                                                     },
                                                     child: Text(
                                                       appLocalizations.clear,
-                                                      style: TextStyle(
-                                                          color: Colors.black),
                                                     ),
                                                   ),
                                                 ],
@@ -280,7 +278,7 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                                       foregroundColor:
                                           hasValues ? primaryRed : Colors.black,
                                       padding: const EdgeInsets.symmetric(
-                                          horizontal: 12, vertical: 4),
+                                          horizontal: 12, vertical: 12),
                                       textStyle: const TextStyle(fontSize: 11),
                                       minimumSize: Size.zero,
                                       tapTargetSize:
@@ -298,23 +296,16 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                                     child: Row(
                                       mainAxisSize: MainAxisSize.min,
                                       children: [
-                                        Icon(
+                                        const Icon(
                                           Icons.refresh,
                                           size: 14,
-                                          color: hasValues
-                                              ? primaryRed
-                                              : Colors.black,
                                         ),
-                                        SizedBox(
-                                            width: MediaQuery.of(context)
-                                                    .size
-                                                    .width *
-                                                0.009),
+                                        const SizedBox(width: 4),
                                         Text(
                                           appLocalizations.clear,
-                                          style: TextStyle(
-                                              color: Colors.black,
-                                              fontSize: 12),
+                                          style: const TextStyle(
+                                            fontSize: 12,
+                                          ),
                                         ),
                                       ],
                                     ),


### PR DESCRIPTION
Fixes #3482

## Changes
1. Fixed the RenderFlex horizontal overflow warning.
3. Increased height for accessibility.

## Screenshots / Recordings

https://github.com/user-attachments/assets/63c8b052-7d98-4946-921d-138e81874d41

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [ ] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [ ] **No end of file edits**: No modifications done at end of resource files.
- [ ] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [ ] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Improve the layout and accessibility of the robotic arm timeline controls’ clear button to avoid horizontal overflow.

Bug Fixes:
- Prevent horizontal overflow warnings in the robotic arm timeline controls by tightening the clear button layout.

Enhancements:
- Increase clear button vertical padding and align its contents for better accessibility and visual consistency.