### PR TITLE
fix: update gas sensor period limit to 5000 ms

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -485,6 +485,7 @@
     "soundmeterConfig": "Soundmeter Configurations",
     "barometerConfig": "Barometer Configurations",
     "baroUpdatePeriodHint": "Please provide time interval at which data will be updated (100 ms to 2000 ms)",
+    "gasUpdatePeriodHint": "Please provide time interval at which data will be updated (100 ms to 5000 ms)",
     "barometerHighLimitHint": "Please provide the maximum limit of atm value to be recorded (0 atm to 1.10 atm)",
     "gyroscopeConfigurations": "Gyroscope Configurations",
     "gyroscopeHighLimitHint": "Please provide the maximum limit of angular velocity value to be recorded (0 rad/s to 1000 rad/s)",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -458,6 +458,7 @@
     "soundmeterConfig": "साउंड मीटर सेटिंग्स",
     "barometerConfig": "बैरोमीटर सेटिंग्स",
     "baroUpdatePeriodHint": "वो टाइम इंटरवल बताएं जिस पर डेटा अपडेट होगा (100 ms से 2000 ms)",
+    "gasUpdatePeriodHint": "वो टाइम इंटरवल बताएं जिस पर डेटा अपडेट होगा (100 ms से 5000 ms)",
     "barometerHighLimitHint": "रिकॉर्ड करने के लिए atm की मैक्स लिमिट बताएं (0 atm से 1.10 atm)",
     "gyroscopeConfigurations": "जायरोस्कोप सेटिंग्स",
     "gyroscopeHighLimitHint": "रिकॉर्ड करने के लिए एंगुलर वेलोसिटी की मैक्स लिमिट बताएं (0 rad/s से 1000 rad/s)",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -458,6 +458,7 @@
     "soundmeterConfig": "Configurazioni Fonometro",
     "barometerConfig": "Configurazioni Barometro",
     "baroUpdatePeriodHint": "Fornisci l'intervallo di tempo in cui i dati verranno aggiornati (da 100 ms a 2000 ms)",
+    "gasUpdatePeriodHint": "Fornisci l'intervallo di tempo in cui i dati verranno aggiornati (da 100 ms a 5000 ms)",
     "barometerHighLimitHint": "Inserisci il limite massimo del valore atm da registrare (da 0 atm a 1.10 atm)",
     "gyroscopeConfigurations": "Configurazioni Giroscopio",
     "gyroscopeHighLimitHint": "Inserisci il limite massimo del valore della velocità angolare da registrare (da 0 rad/s a 1000 rad/s)",

--- a/lib/view/gas_sensor_config_screen.dart
+++ b/lib/view/gas_sensor_config_screen.dart
@@ -88,7 +88,7 @@ class _GasSensorConfigScreenState extends State<GasSensorConfigScreen> {
                               );
                             }
                           },
-                          hint: appLocalizations.baroUpdatePeriodHint,
+                          hint: appLocalizations.gasUpdatePeriodHint,
                         ),
                         ConfigCheckboxItem(
                           title: appLocalizations.locationData,


### PR DESCRIPTION
Fixes #3486

## Changes
Updated the Gas Sensor update period localization hint from 100–2000 ms to 100–5000 ms.

## Screenshots / Recordings'
<img width="787" height="362" alt="image" src="https://github.com/user-attachments/assets/209df3f9-4767-4083-8772-7c1b4a5f00d5" />


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Align gas sensor configuration UI with the correct update period hint and localization entries.

Bug Fixes:
- Use the gas sensor-specific update period hint in the gas sensor configuration screen instead of the barometer hint.

Enhancements:
- Update localized gas sensor update period hint text to reflect the 100–5000 ms range across supported languages.