### PR TITLE
feat: Add device-based instrument filtering

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,11 @@
         android:icon="@mipmap/launcher_icon"
         android:roundIcon="@mipmap/launcher_icon"
         >
+
+        <meta-data
+            android:name="io.flutter.app.android.EnableImpeller"
+            android:value="false" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -31,9 +36,9 @@
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"
+                />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,11 +17,6 @@
         android:icon="@mipmap/launcher_icon"
         android:roundIcon="@mipmap/launcher_icon"
         >
-
-        <meta-data
-            android:name="io.flutter.app.android.EnableImpeller"
-            android:value="false" />
-
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,69 +2,66 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>FLTEnableImpeller</key>
-    <false/>
-
-    <key>CFBundleDevelopmentRegion</key>
-    <string>$(DEVELOPMENT_LANGUAGE)</string>
-    <key>CFBundleDisplayName</key>
-    <string>PSLab</string>
-    <key>CFBundleExecutable</key>
-    <string>$(EXECUTABLE_NAME)</string>
-    <key>CFBundleIdentifier</key>
-    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>CFBundleName</key>
-    <string>pslab</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>CFBundleShortVersionString</key>
-    <string>$(FLUTTER_BUILD_NAME)</string>
-    <key>CFBundleSignature</key>
-    <string>????</string>
-    <key>CFBundleVersion</key>
-    <string>$(FLUTTER_BUILD_NUMBER)</string>
-    <key>LSRequiresIPhoneOS</key>
-    <true/>
-    <key>UILaunchStoryboardName</key>
-    <string>LaunchScreen</string>
-    <key>UIMainStoryboardFile</key>
-    <string>Main</string>
-    <key>NSMicrophoneUsageDescription</key>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>PSLab</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>pslab</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(FLUTTER_BUILD_NAME)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>NSMicrophoneUsageDescription</key>
     <string>App needs Microphone access to capture audio</string>
     <key>NSMotionUsageDescription</key>
     <string>This app uses motion sensors to determine compass direction.</string>
-    <key>NSPhotoLibraryUsageDescription</key>
+	<key>NSPhotoLibraryUsageDescription</key>
     <string>App needs access to photo library</string>
-    <key>NSLocationWhenInUseUsageDescription</key>
-    <string>This app needs access to location.</string>
-    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-    <string>This app needs access to location.</string>
-    <key>UISupportedInterfaceOrientations</key>
-    <array>
-       <string>UIInterfaceOrientationPortrait</string>
-       <string>UIInterfaceOrientationLandscapeLeft</string>
-       <string>UIInterfaceOrientationLandscapeRight</string>
-    </array>
-    <key>UISupportedInterfaceOrientations~ipad</key>
-    <array>
-       <string>UIInterfaceOrientationPortrait</string>
-       <string>UIInterfaceOrientationPortraitUpsideDown</string>
-       <string>UIInterfaceOrientationLandscapeLeft</string>
-       <string>UIInterfaceOrientationLandscapeRight</string>
-    </array>
-    <key>CADisableMinimumFrameDurationOnPhone</key>
-    <true/>
-    <key>UIApplicationSupportsIndirectInputEvents</key>
-    <true/>
-    <key>LSSupportsOpeningDocumentsInPlace</key>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app needs access to location.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app needs access to location.</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
     <true/>
     <key>UIFileSharingEnabled</key>
     <true/>
-    <key>UIRequiresFullScreen</key>
-    <true/>
-    <key>UIApplicationSceneManifest</key>
+	<key>UIRequiresFullScreen</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
       <dict>
         <key>UIApplicationSupportsMultipleScenes</key>
         <false/>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,66 +2,69 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleDisplayName</key>
-	<string>PSLab</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>pslab</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>$(FLUTTER_BUILD_NAME)</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>$(FLUTTER_BUILD_NUMBER)</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
-	<key>NSMicrophoneUsageDescription</key>
+    <key>FLTEnableImpeller</key>
+    <false/>
+
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>PSLab</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>pslab</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(FLUTTER_BUILD_NAME)</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleVersion</key>
+    <string>$(FLUTTER_BUILD_NUMBER)</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+    <key>UIMainStoryboardFile</key>
+    <string>Main</string>
+    <key>NSMicrophoneUsageDescription</key>
     <string>App needs Microphone access to capture audio</string>
     <key>NSMotionUsageDescription</key>
     <string>This app uses motion sensors to determine compass direction.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
+    <key>NSPhotoLibraryUsageDescription</key>
     <string>App needs access to photo library</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>This app needs access to location.</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>This app needs access to location.</string>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>LSSupportsOpeningDocumentsInPlace</key>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>This app needs access to location.</string>
+    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+    <string>This app needs access to location.</string>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+       <string>UIInterfaceOrientationPortrait</string>
+       <string>UIInterfaceOrientationLandscapeLeft</string>
+       <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+       <string>UIInterfaceOrientationPortrait</string>
+       <string>UIInterfaceOrientationPortraitUpsideDown</string>
+       <string>UIInterfaceOrientationLandscapeLeft</string>
+       <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>CADisableMinimumFrameDurationOnPhone</key>
+    <true/>
+    <key>UIApplicationSupportsIndirectInputEvents</key>
+    <true/>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
     <true/>
     <key>UIFileSharingEnabled</key>
     <true/>
-	<key>UIRequiresFullScreen</key>
-	<true/>
-	<key>UIApplicationSceneManifest</key>
+    <key>UIRequiresFullScreen</key>
+    <true/>
+    <key>UIApplicationSceneManifest</key>
       <dict>
         <key>UIApplicationSupportsMultipleScenes</key>
         <false/>

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -944,5 +944,7 @@
     "flasherVariantStandard": "V6 (Standard) : ",
     "flasherBtnDownloadHex": "Download HEX",
     "flasherLocalFileDesc": "Select a pre-compiled .hex file from device storage.",
-    "flasherBtnBrowseFile": "BROWSE FILE"
+    "flasherBtnBrowseFile": "BROWSE FILE",
+    "filterInstrument" : "Filter Instruments",
+    "allInstrument" : "All Instruments"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:pslab/console_helper_dummy.dart'
     if (dart.library.io) 'package:pslab/console_helper.dart' as console_helper;
+import 'package:pslab/providers/instrument_filter_provider.dart';
 
 import 'package:pslab/providers/sht21_provider.dart';
 import 'package:flutter/foundation.dart';
@@ -69,6 +70,7 @@ void main(List<String> args) async {
         ChangeNotifierProvider<BoardStateProvider>(
           create: (context) => getIt<BoardStateProvider>(),
         ),
+        ChangeNotifierProvider(create: (_) => HardwareFilterProvider()),
         ChangeNotifierProvider<SHT21Provider>(
           create: (context) => getIt<SHT21Provider>(),
         ),

--- a/lib/providers/instrument_filter_provider.dart
+++ b/lib/providers/instrument_filter_provider.dart
@@ -4,6 +4,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sensors_plus/sensors_plus.dart';
 import 'package:light/light.dart';
 
+import '../others/logger_service.dart';
+
 enum HardwareMode {
   all,
   inbuiltSensors,
@@ -11,8 +13,8 @@ enum HardwareMode {
 
 class HardwareFilterProvider with ChangeNotifier {
   static const String _prefKey = 'selected_hardware_filter_mode';
-  HardwareMode _currentMode = HardwareMode.all;
 
+  HardwareMode _currentMode = HardwareMode.all;
   bool _hasCheckedSensors = false;
 
   final Map<String, bool> _sensorAvailability = {
@@ -28,45 +30,34 @@ class HardwareFilterProvider with ChangeNotifier {
   HardwareMode get currentMode => _currentMode;
   Map<String, bool> get sensorAvailability => _sensorAvailability;
 
-  HardwareFilterProvider() {
-    _loadSavedMode();
-  }
-
-  Future<void> _loadSavedMode() async {
-    final prefs = await SharedPreferences.getInstance();
-    final index = prefs.getInt(_prefKey) ?? 0;
-    _currentMode =
-        HardwareMode.values[index.clamp(0, HardwareMode.values.length - 1)];
-    notifyListeners();
-
-    if (_currentMode == HardwareMode.inbuiltSensors) {
-      _checkDeviceSensorsDynamically();
-    }
-  }
+  HardwareFilterProvider();
 
   Future<void> setHardwareMode(HardwareMode mode) async {
-    if (_currentMode == mode) return;
+    if (_currentMode == mode) {
+      return;
+    }
     _currentMode = mode;
     notifyListeners();
 
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_prefKey, mode.index);
-
     if (_currentMode == HardwareMode.inbuiltSensors && !_hasCheckedSensors) {
       await _checkDeviceSensorsDynamically();
     }
   }
 
   Future<void> _checkDeviceSensorsDynamically() async {
-    if (_hasCheckedSensors) return;
+    if (_hasCheckedSensors) {
+      return;
+    }
 
     try {
       final results = await Future.wait([
-        _isStreamActive(accelerometerEventStream()),
-        _isStreamActive(gyroscopeEventStream()),
-        _isStreamActive(magnetometerEventStream()),
-        _isStreamActive(barometerEventStream()),
-        _isStreamActive(Light().lightSensorStream),
+        _isStreamActive(accelerometerEventStream(), 'accelerometer'),
+        _isStreamActive(gyroscopeEventStream(), 'gyroscope'),
+        _isStreamActive(magnetometerEventStream(), 'compass'),
+        _isStreamActive(barometerEventStream(), 'barometer'),
+        _isStreamActive(Light().lightSensorStream, 'luxmeter'),
       ]);
 
       _sensorAvailability['/accelerometer'] = results[0];
@@ -78,11 +69,11 @@ class HardwareFilterProvider with ChangeNotifier {
       _hasCheckedSensors = true;
       notifyListeners();
     } catch (e) {
-      debugPrint('Error in dynamic sensor check: $e');
+      logger.d(e);
     }
   }
 
-  Future<bool> _isStreamActive(Stream<dynamic> stream) async {
+  Future<bool> _isStreamActive(Stream<dynamic> stream, String name) async {
     try {
       await stream.first.timeout(const Duration(seconds: 2));
       return true;

--- a/lib/providers/instrument_filter_provider.dart
+++ b/lib/providers/instrument_filter_provider.dart
@@ -13,6 +13,8 @@ class HardwareFilterProvider with ChangeNotifier {
   static const String _prefKey = 'selected_hardware_filter_mode';
   HardwareMode _currentMode = HardwareMode.all;
 
+  bool _hasCheckedSensors = false;
+
   final Map<String, bool> _sensorAvailability = {
     '/luxmeter': false,
     '/accelerometer': false,
@@ -28,7 +30,6 @@ class HardwareFilterProvider with ChangeNotifier {
 
   HardwareFilterProvider() {
     _loadSavedMode();
-    _checkDeviceSensorsDynamically();
   }
 
   Future<void> _loadSavedMode() async {
@@ -37,17 +38,28 @@ class HardwareFilterProvider with ChangeNotifier {
     _currentMode =
         HardwareMode.values[index.clamp(0, HardwareMode.values.length - 1)];
     notifyListeners();
+
+    if (_currentMode == HardwareMode.inbuiltSensors) {
+      _checkDeviceSensorsDynamically();
+    }
   }
 
   Future<void> setHardwareMode(HardwareMode mode) async {
     if (_currentMode == mode) return;
     _currentMode = mode;
     notifyListeners();
+
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_prefKey, mode.index);
+
+    if (_currentMode == HardwareMode.inbuiltSensors && !_hasCheckedSensors) {
+      await _checkDeviceSensorsDynamically();
+    }
   }
 
   Future<void> _checkDeviceSensorsDynamically() async {
+    if (_hasCheckedSensors) return;
+
     try {
       final results = await Future.wait([
         _isStreamActive(accelerometerEventStream()),
@@ -62,6 +74,8 @@ class HardwareFilterProvider with ChangeNotifier {
       _sensorAvailability['/compass'] = results[2];
       _sensorAvailability['/barometer'] = results[3];
       _sensorAvailability['/luxmeter'] = results[4];
+
+      _hasCheckedSensors = true;
       notifyListeners();
     } catch (e) {
       debugPrint('Error in dynamic sensor check: $e');

--- a/lib/providers/instrument_filter_provider.dart
+++ b/lib/providers/instrument_filter_provider.dart
@@ -4,6 +4,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sensors_plus/sensors_plus.dart';
 import 'package:light/light.dart';
 
+import '../others/logger_service.dart' show logger;
+
 enum HardwareMode {
   all,
   inbuiltSensors,
@@ -11,8 +13,8 @@ enum HardwareMode {
 
 class HardwareFilterProvider with ChangeNotifier {
   static const String _prefKey = 'selected_hardware_filter_mode';
-  HardwareMode _currentMode = HardwareMode.all;
 
+  HardwareMode _currentMode = HardwareMode.all;
   bool _hasCheckedSensors = false;
 
   final Map<String, bool> _sensorAvailability = {
@@ -28,24 +30,12 @@ class HardwareFilterProvider with ChangeNotifier {
   HardwareMode get currentMode => _currentMode;
   Map<String, bool> get sensorAvailability => _sensorAvailability;
 
-  HardwareFilterProvider() {
-    _loadSavedMode();
-  }
-
-  Future<void> _loadSavedMode() async {
-    final prefs = await SharedPreferences.getInstance();
-    final index = prefs.getInt(_prefKey) ?? 0;
-    _currentMode =
-        HardwareMode.values[index.clamp(0, HardwareMode.values.length - 1)];
-    notifyListeners();
-
-    if (_currentMode == HardwareMode.inbuiltSensors) {
-      _checkDeviceSensorsDynamically();
-    }
-  }
+  HardwareFilterProvider();
 
   Future<void> setHardwareMode(HardwareMode mode) async {
-    if (_currentMode == mode) return;
+    if (_currentMode == mode) {
+      return;
+    }
     _currentMode = mode;
     notifyListeners();
 
@@ -58,15 +48,17 @@ class HardwareFilterProvider with ChangeNotifier {
   }
 
   Future<void> _checkDeviceSensorsDynamically() async {
-    if (_hasCheckedSensors) return;
+    if (_hasCheckedSensors) {
+      return;
+    }
 
     try {
       final results = await Future.wait([
-        _isStreamActive(accelerometerEventStream()),
-        _isStreamActive(gyroscopeEventStream()),
-        _isStreamActive(magnetometerEventStream()),
-        _isStreamActive(barometerEventStream()),
-        _isStreamActive(Light().lightSensorStream),
+        _isStreamActive(accelerometerEventStream(), 'accelerometer'),
+        _isStreamActive(gyroscopeEventStream(), 'gyroscope'),
+        _isStreamActive(magnetometerEventStream(), 'compass'),
+        _isStreamActive(barometerEventStream(), 'barometer'),
+        _isStreamActive(Light().lightSensorStream, 'luxmeter'),
       ]);
 
       _sensorAvailability['/accelerometer'] = results[0];
@@ -78,11 +70,12 @@ class HardwareFilterProvider with ChangeNotifier {
       _hasCheckedSensors = true;
       notifyListeners();
     } catch (e) {
-      debugPrint('Error in dynamic sensor check: $e');
+      logger.d(
+          'TRACE [HardwareFilterProvider]: Error checking device sensors: $e');
     }
   }
 
-  Future<bool> _isStreamActive(Stream<dynamic> stream) async {
+  Future<bool> _isStreamActive(Stream<dynamic> stream, String name) async {
     try {
       await stream.first.timeout(const Duration(seconds: 2));
       return true;

--- a/lib/providers/instrument_filter_provider.dart
+++ b/lib/providers/instrument_filter_provider.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sensors_plus/sensors_plus.dart';
+import 'package:light/light.dart';
+
+enum HardwareMode {
+  all,
+  inbuiltSensors,
+}
+
+class HardwareFilterProvider with ChangeNotifier {
+  static const String _prefKey = 'selected_hardware_filter_mode';
+  HardwareMode _currentMode = HardwareMode.all;
+
+  final Map<String, bool> _sensorAvailability = {
+    '/luxmeter': false,
+    '/accelerometer': false,
+    '/barometer': false,
+    '/compass': false,
+    '/gyroscope': false,
+    '/thermometer': false,
+    '/soundmeter': true,
+  };
+
+  HardwareMode get currentMode => _currentMode;
+  Map<String, bool> get sensorAvailability => _sensorAvailability;
+
+  HardwareFilterProvider() {
+    _loadSavedMode();
+    _checkDeviceSensorsDynamically();
+  }
+
+  Future<void> _loadSavedMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final index = prefs.getInt(_prefKey) ?? 0;
+    _currentMode =
+        HardwareMode.values[index.clamp(0, HardwareMode.values.length - 1)];
+    notifyListeners();
+  }
+
+  Future<void> setHardwareMode(HardwareMode mode) async {
+    if (_currentMode == mode) return;
+    _currentMode = mode;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_prefKey, mode.index);
+  }
+
+  Future<void> _checkDeviceSensorsDynamically() async {
+    try {
+      final results = await Future.wait([
+        _isStreamActive(accelerometerEventStream()),
+        _isStreamActive(gyroscopeEventStream()),
+        _isStreamActive(magnetometerEventStream()),
+        _isStreamActive(barometerEventStream()),
+        _isStreamActive(Light().lightSensorStream),
+      ]);
+
+      _sensorAvailability['/accelerometer'] = results[0];
+      _sensorAvailability['/gyroscope'] = results[1];
+      _sensorAvailability['/compass'] = results[2];
+      _sensorAvailability['/barometer'] = results[3];
+      _sensorAvailability['/luxmeter'] = results[4];
+      notifyListeners();
+    } catch (e) {
+      debugPrint('Error in dynamic sensor check: $e');
+    }
+  }
+
+  Future<bool> _isStreamActive(Stream<dynamic> stream) async {
+    try {
+      await stream.first.timeout(const Duration(seconds: 2));
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/lib/view/instruments_screen.dart
+++ b/lib/view/instruments_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 import 'package:pslab/constants.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/board_state_provider.dart';
+import 'package:pslab/providers/instrument_filter_provider.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/view/widgets/applications_list_item.dart';
 import 'package:pslab/view/widgets/main_scaffold_widget.dart';
@@ -23,6 +25,7 @@ class _InstrumentData {
 
 class _InstrumentsScreenState extends State<InstrumentsScreen> {
   List<int> _filteredIndices = <int>[];
+  String _searchQuery = '';
   AppLocalizations get appLocalizations => getIt.get<AppLocalizations>();
   late List<_InstrumentData> _instrumentDatas;
 
@@ -41,19 +44,48 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
     }
   }
 
-  void _filterInstruments(String query) {
-    setState(() {
-      if (query.isEmpty) {
-        _filteredIndices =
-            List<int>.generate(_instrumentDatas.length, (index) => index);
-      } else {
-        _filteredIndices = List.generate(_instrumentDatas.length, (i) => i)
-            .where((i) => _instrumentDatas[i]
-                .heading
-                .toLowerCase()
-                .contains(query.toLowerCase()))
-            .toList();
+  void _onSearchChanged(String query) {
+    _searchQuery = query;
+    _applyFilters();
+  }
+
+  void _applyFilters() {
+    final filterProvider =
+        Provider.of<HardwareFilterProvider>(context, listen: false);
+    final mode = filterProvider.currentMode;
+    final sensorAvailability = filterProvider.sensorAvailability;
+
+    final List<int> indices = [];
+
+    for (int i = 0; i < _instrumentDatas.length; i++) {
+      final instrument = _instrumentDatas[i];
+      final route = instrument.name;
+
+      if (mode == HardwareMode.inbuiltSensors) {
+        if (route == '/oscilloscope' || route == '/waveGenerator') {
+        } else if (sensorAvailability.containsKey(route)) {
+          final bool isAvailable = sensorAvailability[route] ?? false;
+          if (!isAvailable) {
+            continue;
+          }
+        } else {
+          continue;
+        }
       }
+      if (_searchQuery.isNotEmpty) {
+        final matchesQuery = instrument.heading
+            .toLowerCase()
+            .contains(_searchQuery.toLowerCase());
+        if (!matchesQuery) {
+          continue;
+        }
+      }
+
+      indices.add(i);
+    }
+
+    setState(() {
+      _filteredIndices = indices;
     });
   }
 
@@ -115,11 +147,9 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
           appLocalizations.roboticArmDesc, '/roboticArm'),
       _InstrumentData(appLocalizations.gasSensor,
           appLocalizations.gasSensorDesc, '/gassensor'),
-
       // _InstrumentData(appLocalizations.dustSensor, appLocalizations.dustSensorDesc, '/dustsensor'),
       _InstrumentData(appLocalizations.soundMeter,
           appLocalizations.soundMeterDesc, '/soundmeter'),
-
       _InstrumentData(
           'OLED Display',
           'Draw shapes & render text on an external OLED display.',
@@ -128,9 +158,11 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
 
     _filteredIndices =
         List<int>.generate(_instrumentDatas.length, (index) => index);
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _setPortraitOrientation();
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+      _applyFilters();
     });
   }
 
@@ -143,21 +175,25 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
 
   @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     if (ModalRoute.of(context)?.isCurrent ?? true) {
       _setPortraitOrientation();
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     }
-    super.didChangeDependencies();
   }
 
   @override
   Widget build(BuildContext context) {
+    context.watch<HardwareFilterProvider>();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _applyFilters());
+
     return MainScaffold(
       index: 0,
       scaffoldKey: const Key(instrumentsScreenTitleKey),
       title: appLocalizations.instrumentsTitle,
       showSearch: true,
-      onSearchChanged: _filterInstruments,
+      showFilter: true,
+      onSearchChanged: _onSearchChanged,
       searchHint: appLocalizations.searchInstrumentsHint,
       body: SafeArea(
         child: _filteredIndices.isEmpty

--- a/lib/view/instruments_screen.dart
+++ b/lib/view/instruments_screen.dart
@@ -45,8 +45,9 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
   }
 
   void _onSearchChanged(String query) {
-    _searchQuery = query;
-    _applyFilters();
+    setState(() {
+      _searchQuery = query;
+    });
   }
 
   void _applyFilters() {
@@ -84,9 +85,7 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
       indices.add(i);
     }
 
-    setState(() {
-      _filteredIndices = indices;
-    });
+    _filteredIndices = indices;
   }
 
   @override
@@ -147,7 +146,6 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
           appLocalizations.roboticArmDesc, '/roboticArm'),
       _InstrumentData(appLocalizations.gasSensor,
           appLocalizations.gasSensorDesc, '/gassensor'),
-      // _InstrumentData(appLocalizations.dustSensor, appLocalizations.dustSensorDesc, '/dustsensor'),
       _InstrumentData(appLocalizations.soundMeter,
           appLocalizations.soundMeterDesc, '/soundmeter'),
       _InstrumentData(
@@ -156,13 +154,9 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
           '/oledDisplay'),
     ];
 
-    _filteredIndices =
-        List<int>.generate(_instrumentDatas.length, (index) => index);
-
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _setPortraitOrientation();
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-      _applyFilters();
     });
   }
 
@@ -185,7 +179,7 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
   @override
   Widget build(BuildContext context) {
     context.watch<HardwareFilterProvider>();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _applyFilters());
+    _applyFilters();
 
     return MainScaffold(
       index: 0,

--- a/lib/view/widgets/main_scaffold_widget.dart
+++ b/lib/view/widgets/main_scaffold_widget.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:pslab/providers/board_state_provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
+import '../../providers/instrument_filter_provider.dart';
 import '../../theme/colors.dart';
 import '../pin_layout_screen.dart';
 import 'navigation_drawer.dart';
@@ -18,6 +19,7 @@ class MainScaffold extends StatefulWidget {
   final String icUsbConnected = 'assets/icons/ic_usb_connected.png';
   final String icWiFiConnected = 'assets/icons/ic_wifi_connected.png';
   final bool showSearch;
+  final bool showFilter;
   final Function(String)? onSearchChanged;
   final String? searchHint;
 
@@ -29,6 +31,7 @@ class MainScaffold extends StatefulWidget {
     this.actions,
     required this.index,
     this.showSearch = false,
+    this.showFilter = true,
     this.onSearchChanged,
     this.searchHint,
   });
@@ -246,6 +249,55 @@ class _MainScaffoldState extends State<MainScaffold>
                     );
                   },
                 ),
+                if (widget.showFilter)
+                  Consumer<HardwareFilterProvider>(
+                    builder: (context, filterProvider, _) {
+                      return PopupMenuButton<HardwareMode>(
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          side: const BorderSide(
+                            color: Colors.white,
+                            width: 1.5,
+                          ),
+                        ),
+                        elevation: 6,
+                        offset: const Offset(0, 45),
+                        color: Colors.white,
+                        icon: Icon(
+                          filterProvider.currentMode == HardwareMode.all
+                              ? Icons.filter_list
+                              : Icons.filter_list_alt,
+                          color: appBarContentColor,
+                          size: iconGlyph,
+                        ),
+                        tooltip: appLocalizations.filterInstrument,
+                        padding: EdgeInsets.symmetric(horizontal: btnHPad),
+                        constraints: BoxConstraints(
+                          minWidth: btnMin,
+                          minHeight: btnMin,
+                        ),
+                        initialValue: filterProvider.currentMode,
+                        onSelected: (HardwareMode mode) {
+                          filterProvider.setHardwareMode(mode);
+                        },
+                        itemBuilder: (BuildContext context) => [
+                          _buildStyledFilterItem(
+                            context,
+                            mode: HardwareMode.all,
+                            label: appLocalizations.allInstrument,
+                            selectedMode: filterProvider.currentMode,
+                          ),
+                          const PopupMenuDivider(height: 1),
+                          _buildStyledFilterItem(
+                            context,
+                            mode: HardwareMode.inbuiltSensors,
+                            label: appLocalizations.builtIn,
+                            selectedMode: filterProvider.currentMode,
+                          ),
+                        ],
+                      );
+                    },
+                  ),
                 PopupMenuButton<String>(
                   icon: Icon(
                     Icons.more_vert,
@@ -295,6 +347,39 @@ class _MainScaffoldState extends State<MainScaffold>
       body: widget.body,
       drawer: NavDrawer(
         selectedIndex: widget.index,
+      ),
+    );
+  }
+
+  PopupMenuItem<HardwareMode> _buildStyledFilterItem(
+    BuildContext context, {
+    required HardwareMode mode,
+    required String label,
+    required HardwareMode selectedMode,
+  }) {
+    final bool isSelected = mode == selectedMode;
+    final Color color =
+        isSelected ? Theme.of(context).primaryColor : Colors.black87;
+
+    return PopupMenuItem<HardwareMode>(
+      value: mode,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                label,
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+                  color: color,
+                ),
+              ),
+            ),
+            if (isSelected) Icon(Icons.check, size: 20, color: color),
+          ],
+        ),
       ),
     );
   }

--- a/test_integration/screenshots.dart
+++ b/test_integration/screenshots.dart
@@ -20,7 +20,7 @@ void main() async {
   group('E2E Group', () {
     testWidgets('Take Screenshots', (tester) async {
       app.main([]);
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 3));
 
       final instrumentsScreenTitle =
           find.byKey(const ValueKey(instrumentsScreenTitleKey));
@@ -44,7 +44,7 @@ void main() async {
           scrollable: find.byType(Scrollable),
           maxScrolls: 50,
         );
-        await tester.pumpAndSettle();
+        await tester.pump(const Duration(seconds: 1));
       }
 
       await pumpUntilFound(tester, instrumentsScreenTitle);
@@ -53,13 +53,14 @@ void main() async {
 
       ScaffoldState state = tester.firstState(find.byType(Scaffold));
       state.openDrawer();
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 1));
+
       await pumpUntilFound(tester, notConnectedText);
       await tester.pump(const Duration(seconds: 1));
       await binding.takeScreenshot('2_nav_drawer');
 
       state.closeDrawer();
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 1));
 
       final accelerometerCard = find.text('ACCELEROMETER');
       await tester.scrollUntilVisible(
@@ -67,7 +68,7 @@ void main() async {
         200.0,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 1));
       await tester.tap(accelerometerCard);
       await tester.pump(const Duration(seconds: 2));
 
@@ -94,7 +95,7 @@ void main() async {
         200.0,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 1));
       await tester.tap(powerSourceCard);
       await pumpUntilFound(tester, powerSourceScreenTitle);
       await tester.pump(const Duration(seconds: 2));
@@ -112,7 +113,7 @@ void main() async {
         200.0,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 1));
       await tester.tap(multimeterCard);
       await pumpUntilFound(tester, multimeterScreenTitle);
       await tester.pump(const Duration(seconds: 2));
@@ -130,7 +131,7 @@ void main() async {
         200.0,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 1));
       await tester.tap(waveGeneratorCard);
       await pumpUntilFound(tester, waveGeneratorScreenTitle);
 
@@ -153,7 +154,7 @@ void main() async {
         200.0,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 1));
       await tester.tap(oscilloscopeCard);
       await pumpUntilFound(tester, oscilloscopeScreenTitle);
       await tester.pump(const Duration(seconds: 2));

--- a/test_integration/screenshots.dart
+++ b/test_integration/screenshots.dart
@@ -20,7 +20,7 @@ void main() async {
   group('E2E Group', () {
     testWidgets('Take Screenshots', (tester) async {
       app.main([]);
-      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpAndSettle();
 
       final instrumentsScreenTitle =
           find.byKey(const ValueKey(instrumentsScreenTitleKey));
@@ -44,7 +44,7 @@ void main() async {
           scrollable: find.byType(Scrollable),
           maxScrolls: 50,
         );
-        await tester.pump(const Duration(seconds: 1));
+        await tester.pumpAndSettle();
       }
 
       await pumpUntilFound(tester, instrumentsScreenTitle);
@@ -53,14 +53,13 @@ void main() async {
 
       ScaffoldState state = tester.firstState(find.byType(Scaffold));
       state.openDrawer();
-      await tester.pump(const Duration(seconds: 1));
-
+      await tester.pumpAndSettle();
       await pumpUntilFound(tester, notConnectedText);
       await tester.pump(const Duration(seconds: 1));
       await binding.takeScreenshot('2_nav_drawer');
 
       state.closeDrawer();
-      await tester.pump(const Duration(seconds: 1));
+      await tester.pumpAndSettle();
 
       final accelerometerCard = find.text('ACCELEROMETER');
       await tester.scrollUntilVisible(
@@ -68,7 +67,7 @@ void main() async {
         200.0,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pump(const Duration(seconds: 1));
+      await tester.pumpAndSettle();
       await tester.tap(accelerometerCard);
       await tester.pump(const Duration(seconds: 2));
 
@@ -95,7 +94,7 @@ void main() async {
         200.0,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pump(const Duration(seconds: 1));
+      await tester.pumpAndSettle();
       await tester.tap(powerSourceCard);
       await pumpUntilFound(tester, powerSourceScreenTitle);
       await tester.pump(const Duration(seconds: 2));
@@ -113,7 +112,7 @@ void main() async {
         200.0,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pump(const Duration(seconds: 1));
+      await tester.pumpAndSettle();
       await tester.tap(multimeterCard);
       await pumpUntilFound(tester, multimeterScreenTitle);
       await tester.pump(const Duration(seconds: 2));
@@ -131,7 +130,7 @@ void main() async {
         200.0,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pump(const Duration(seconds: 1));
+      await tester.pumpAndSettle();
       await tester.tap(waveGeneratorCard);
       await pumpUntilFound(tester, waveGeneratorScreenTitle);
 
@@ -154,7 +153,7 @@ void main() async {
         200.0,
         scrollable: find.byType(Scrollable),
       );
-      await tester.pump(const Duration(seconds: 1));
+      await tester.pumpAndSettle();
       await tester.tap(oscilloscopeCard);
       await pumpUntilFound(tester, oscilloscopeScreenTitle);
       await tester.pump(const Duration(seconds: 2));


### PR DESCRIPTION
Fixes #3334

## Changes

- Added an instrument filtering feature to the main scaffold.
- Users can now filter instruments based on:
  - All instruments
  - Instruments with sensors available on the user's device
- PSLab V5/V6 filters were not added, as all instruments support both versions. Therefore, there would be no difference between the **All Instruments** filter and separate **PSLab V5/V6** filters.
- While the issue suggests showing the popup every time the app is opened, I think this could become intrusive, especially for developers and frequent users. 

## Screenshots / Recordings
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

https://github.com/user-attachments/assets/08a0c297-0033-4d62-8ec6-a942e9b065dd

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`

## Summary by Sourcery

Enable users to filter instruments based on the hardware sensors available on their device.

New Features:
- Add instrument filtering by all instruments or sensors available on the user’s device.
- Add a persistent filter menu to the main scaffold and integrate it with instrument search results.

Enhancements:
- Detect device sensor availability dynamically and update the instrument list accordingly.

Chores:
- Add localized labels for the instrument filter options.

## Summary by Sourcery

Enable device-aware instrument filtering from the main instrument screen.

New Features:
- Add an instrument filter menu that lets users view all instruments or only those supported by sensors on their device.

Enhancements:
- Detect available device sensors dynamically and combine hardware filtering with instrument search.
- Persist the selected instrument filter mode across sessions.

Chores:
- Add localized labels for the available instrument filter options.