### PR TITLE
fix: replace deprecated CLLocationManager

### DIFF
--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -61,7 +61,7 @@ class MainFlutterWindow: NSWindow, CLLocationManagerDelegate {
     private func checkLocationStatus(result: @escaping FlutterResult) {
         let status: CLAuthorizationStatus
         if #available(macOS 11.0, *) {
-            status = locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
+            status = locationManager?.authorizationStatus ?? .notDetermined
         } else {
             status = CLLocationManager.authorizationStatus()
         }
@@ -95,7 +95,7 @@ class MainFlutterWindow: NSWindow, CLLocationManagerDelegate {
     private func requestLocation(result: @escaping FlutterResult) {
         let status: CLAuthorizationStatus
         if #available(macOS 11.0, *) {
-            status = self.locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
+            status = self.locationManager?.authorizationStatus ?? .notDetermined
         } else {
             status = CLLocationManager.authorizationStatus()
         }


### PR DESCRIPTION
Fixes #3504

## Changes
Replaced the deprecated CLLocationManager.authorizationStatus() fallback with .notDetermined

## Screenshots / Recordings
N/A, this is a native macOS API/deprecation fix with no UI changes.

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Replace the deprecated macOS location authorization fallback with `.notDetermined` on supported macOS versions.