### PR TITLE
fix: Apply buffer overlay to stacked oscilloscope charts

### DIFF
--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -1261,6 +1261,23 @@ class OscilloscopeStateProvider extends ChangeNotifier {
   List<LineChartBarData> createPlotForChannel(String channelName) {
     final index = dataParamsChannels.indexOf(channelName);
     final plots = <LineChartBarData>[];
+    if (_configProvider.config.bufferOverlayEnabled && index >= 0) {
+      for (int b = 0; b < _waveformBuffer.length; b++) {
+        if (index >= _waveformBuffer[b].length) continue;
+        final age = b + 1;
+        final opacity =
+            (1.0 - (age / (_waveformBuffer.length + 1))).clamp(0.1, 0.6);
+        plots.add(
+          LineChartBarData(
+            spots: _waveformBuffer[b][index],
+            isCurved: true,
+            color: colors[index % colors.length].withValues(alpha: opacity),
+            barWidth: 1,
+            dotData: const FlDotData(show: false),
+          ),
+        );
+      }
+    }
     if (index >= 0 && index < dataEntries.length) {
       plots.add(
         LineChartBarData(


### PR DESCRIPTION
Fixes #3471

## Changes
Buffer Overlay Mode is meant to show faded traces of recent past waveform frames layered behind the current one, so you can visually compare how a signal changes over time. This worked correctly in the normal (non-stacked) oscilloscope view, but had no visible effect when Stacked Mode was also enabled.

The two view modes use separate rendering paths:
- The non-stacked view builds its chart data in  `OscilloscopeStateProvider.createPlots()`, which already looped over the buffered waveform history and rendered each past frame with decreasing opacity.
- The stacked view (one pane per channel) builds its chart data in `OscilloscopeStateProvider.createPlotForChannel()`, which only ever added
  the current frame and never read from the waveform buffer at all.

This PR updates `createPlotForChannel()` to replay the same buffered history for its single channel, using the same age-based opacity fade as the non-stacked view, so Buffer Overlay Mode now behaves consistently whether or not Stacked Mode is on.

**File changed:** `lib/providers/oscilloscope_state_provider.dart` (`createPlotForChannel` method only — no other files needed changes, since the stacked chart widget already calls this method per channel).

## Screenshots / Recordings
N/A — I don't currently have a physical PSLab device available to generate
live waveform data for a before/after recording. I verified the fix by:
- Tracing the code path by hand to confirm `createPlotForChannel()` now mirrors the buffer-replay logic already used in `createPlots()`.
- Running `flutter test`, which passed (7/7).
- Running `dart format`, which reported no changes needed.

Happy to add a recording once I have access to the hardware, or if a maintainer can point me to a way to simulate waveform data for testing.

**Checklist**:
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Apply buffered waveform overlays to each channel in stacked oscilloscope charts so recent signal history is visible with age-based fading.