### PR TITLE
fix: enable outbound network connections

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -16,5 +16,7 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -12,5 +12,7 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #3509

## Changes
- Added the com.apple.security.network.client entitlement to the macOS application

## Screenshots / Recordings
Before:
<img height="500" alt="Image" src="https://github.com/user-attachments/assets/d9bd6783-46d6-4700-b84a-0958f1b7b0fe" />

After:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/4207ca36-e73b-4a81-8dab-915c4f0ec4ba" />

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Enable outbound network connections for the macOS application in both debug/profile and release builds.