### PR TITLE
fix: Scale automated measurements font to widget width, not window width

### DIFF
--- a/lib/view/widgets/measurements_list.dart
+++ b/lib/view/widgets/measurements_list.dart
@@ -13,13 +13,12 @@ class MeasurementsList extends StatefulWidget {
   State<StatefulWidget> createState() => _MeasurementsListState();
 }
 
-double _responsiveFont(BuildContext context, double baseFont) {
-  const referenceWidth = 1440.0;
-  const minFontSize = 6.0;
-  const maxFontSize = 32.0;
+double _responsiveFont(double availableWidth, double baseFont) {
+  const referenceWidth = 220.0;
+  const minFontSize = 8.0;
+  const maxFontSize = 16.0;
 
-  final width = MediaQuery.sizeOf(context).width;
-  final scaled = (width / referenceWidth) * baseFont;
+  final scaled = (availableWidth / referenceWidth) * baseFont;
 
   return scaled.clamp(minFontSize, maxFontSize).toDouble();
 }
@@ -33,66 +32,71 @@ class _MeasurementsListState extends State<MeasurementsList> {
 
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
-      shrinkWrap: true,
-      itemCount: widget.dataParamsChannels.length,
-      physics: const ClampingScrollPhysics(),
-      itemBuilder: (context, index) {
-        final textStyle = TextStyle(
-          color: colors[index],
-          fontSize: _responsiveFont(context, 16),
-        );
-        final channel = widget.dataParamsChannels[index];
-        return Card(
-          elevation: 8,
-          color: Colors.grey[800],
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(5),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 2.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return ListView.builder(
+          shrinkWrap: true,
+          itemCount: widget.dataParamsChannels.length,
+          physics: const ClampingScrollPhysics(),
+          itemBuilder: (context, index) {
+            final textStyle = TextStyle(
+              color: colors[index],
+              fontSize: _responsiveFont(constraints.maxWidth, 16),
+            );
+            final channel = widget.dataParamsChannels[index];
+            return Card(
+              elevation: 8,
+              color: Colors.grey[800],
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(5),
+              ),
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 4.0, vertical: 2.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Expanded(
-                      child: Text(
-                        'Vpp: ${OscilloscopeMeasurements.channel[channel]?[ChannelMeasurements.amplitude]?.toStringAsFixed(2)} V',
-                        style: textStyle,
-                      ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            'Vpp: ${OscilloscopeMeasurements.channel[channel]?[ChannelMeasurements.amplitude]?.toStringAsFixed(2)} V',
+                            style: textStyle,
+                          ),
+                        ),
+                        Expanded(
+                          child: Text(
+                            'Vp+: ${OscilloscopeMeasurements.channel[channel]?[ChannelMeasurements.positivePeak]?.toStringAsFixed(2)} V',
+                            style: textStyle,
+                          ),
+                        ),
+                      ],
                     ),
-                    Expanded(
-                      child: Text(
-                        'Vp+: ${OscilloscopeMeasurements.channel[channel]?[ChannelMeasurements.positivePeak]?.toStringAsFixed(2)} V',
-                        style: textStyle,
-                      ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            'Vp-: ${OscilloscopeMeasurements.channel[channel]?[ChannelMeasurements.negativePeak]?.toStringAsFixed(2)} V',
+                            style: textStyle,
+                          ),
+                        ),
+                        Expanded(
+                          child: Text(
+                            'f: ${formatFrequency(OscilloscopeMeasurements.channel[channel]?[ChannelMeasurements.frequency] ?? 0.0)}',
+                            style: textStyle,
+                          ),
+                        ),
+                      ],
+                    ),
+                    Text(
+                      'P: ${OscilloscopeMeasurements.channel[channel]?[ChannelMeasurements.period]?.toStringAsFixed(2)} ms',
+                      style: textStyle,
                     ),
                   ],
                 ),
-                Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        'Vp-: ${OscilloscopeMeasurements.channel[channel]?[ChannelMeasurements.negativePeak]?.toStringAsFixed(2)} V',
-                        style: textStyle,
-                      ),
-                    ),
-                    Expanded(
-                      child: Text(
-                        'f: ${formatFrequency(OscilloscopeMeasurements.channel[channel]?[ChannelMeasurements.frequency] ?? 0.0)}',
-                        style: textStyle,
-                      ),
-                    ),
-                  ],
-                ),
-                Text(
-                  'P: ${OscilloscopeMeasurements.channel[channel]?[ChannelMeasurements.period]?.toStringAsFixed(2)} ms',
-                  style: textStyle,
-                ),
-              ],
-            ),
-          ),
+              ),
+            );
+          },
         );
       },
     );

--- a/test/measurements_list_font_test.dart
+++ b/test/measurements_list_font_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pslab/view/widgets/measurements_list.dart';
+
+void main() {
+  Future<double> pumpAndGetFontSize(
+    WidgetTester tester, {
+    required Size windowSize,
+    required double boxWidth,
+  }) async {
+    tester.view.physicalSize = windowSize;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: boxWidth,
+            child: const MeasurementsList(dataParamsChannels: ['CH1']),
+          ),
+        ),
+      ),
+    );
+
+    final text = tester.widget<Text>(find.textContaining('Vpp:').first);
+    return text.style!.fontSize!;
+  }
+
+  testWidgets(
+    'measurement font size depends on the widget box, not the window',
+    (tester) async {
+      final fontSmallWindow = await pumpAndGetFontSize(
+        tester,
+        windowSize: const Size(800, 600),
+        boxWidth: 200,
+      );
+
+      final fontLargeWindow = await pumpAndGetFontSize(
+        tester,
+        windowSize: const Size(2400, 1400),
+        boxWidth: 200,
+      );
+
+      expect(fontSmallWindow, fontLargeWindow);
+    },
+  );
+}


### PR DESCRIPTION
Fixes #3460

## Changes
The automated measurements card on the Oscilloscope screen scaled its font size using `MediaQuery.sizeOf(context).width` — the full app window width — while the card itself is constrained to 100-350px by its parent widget in `oscilloscope_screen.dart`. This meant the text size changed with the window even though the card's own size didn't, causing overflow/clipping on wide windows.

- `lib/view/widgets/measurements_list.dart`: wrapped the build method in a `LayoutBuilder` and scale the font from the card's own `constraints.maxWidth` instead of the window width.
- Added `test/measurements_list_font_test.dart` to verify the font size stays the same when the app window is resized but the card's own width doesn't change.

**Checklist**:
- [x] **No hard coding**: no new user-facing strings were added.
- [x] **No end of file edits**: no trailing edits made.
- [x] **Code reformatting**: ran `dart format` on changed files.
- [x] **Code analysis**: `flutter analyze` and `flutter test` pass.

## Summary by Sourcery

Scale automated measurement fonts according to the measurements card width to keep text sizing consistent across window layouts.

Bug Fixes:
- Scale automated measurement text from the widget’s constrained width instead of the overall application window, preventing incorrect sizing and overflow when windows are resized.

Tests:
- Add widget coverage verifying measurement font size remains stable across window sizes when the widget width is unchanged.