### PR TITLE
fix: detect PSLab when multiple USB COM devices are connected

### DIFF
--- a/lib/communication/handler/comms_handler.dart
+++ b/lib/communication/handler/comms_handler.dart
@@ -26,6 +26,7 @@ class PSLabCommunicationHandler implements CommunicationHandler {
 
   @override
   bool deviceFound = false;
+  String? targetPortName;
 
   @override
   Future<void> initialize() async {
@@ -38,7 +39,7 @@ class PSLabCommunicationHandler implements CommunicationHandler {
     }
 
     if (deviceFound) {
-      logger.d("Found PSLab device");
+      logger.d("Found COM device");
     } else {
       logger.d("No drivers found");
     }
@@ -46,48 +47,48 @@ class PSLabCommunicationHandler implements CommunicationHandler {
 
   @override
   Future<void> open({int overrideBaud = 1000000}) async {
-    if (!deviceFound) {
-      throw Exception("Device not connected");
-    }
-
-    if (kIsWeb) {
-      throw Exception("Native USB not supported on Web. Use WebCommsHandler.");
-    }
+    if (!deviceFound) throw Exception("Device not connected");
+    if (kIsWeb) throw Exception("Native USB not supported on Web.");
 
     rust_api.closeUsb();
-
     bool boardConnected = false;
-
-    for (final board in supportedBoards) {
+    if (targetPortName != null &&
+        (Platform.isWindows || Platform.isMacOS || Platform.isLinux)) {
       try {
-        if (Platform.isAndroid) {
-          logger.d(
-              "Probing Android for ${board.version} (VID: ${board.vid}, PID: ${board.pid})...");
-          final int fd = await _androidChannel.invokeMethod('getAndroidFd', {
-            "vid": board.vid,
-            "pid": board.pid,
-          });
-          logger.d("Got FD from Android: $fd. Handing to Rust...");
-          await rust_api.initAndroid(fd: fd);
-        } else {
-          logger.d("Probing Desktop for ${board.version}...");
-          await rust_api.initDesktop(vid: board.vid, pid: board.pid);
-        }
-
-        logger.d(
-            "Port opened for ${board.version} chip. Waiting for PSLab handshake...");
+        logger.d("Attempting connection on specific port: $targetPortName");
+        await rust_api.initDesktopByPort(portName: targetPortName!);
         boardConnected = true;
-        break;
       } catch (e) {
-        logger.w("Failed on ${board.version}: $e");
-        continue;
+        logger.w("Failed to open $targetPortName: $e");
+      }
+    } else {
+      for (final board in supportedBoards) {
+        try {
+          if (Platform.isAndroid) {
+            logger.d("Probing Android for ${board.version}...");
+            final int fd = await _androidChannel.invokeMethod('getAndroidFd', {
+              "vid": board.vid,
+              "pid": board.pid,
+            });
+            await rust_api.initAndroid(fd: fd);
+            boardConnected = true;
+            break;
+          } else {
+            logger.d("Probing Desktop for ${board.version}...");
+            await rust_api.initDesktop(vid: board.vid, pid: board.pid);
+            boardConnected = true;
+            break;
+          }
+        } catch (e) {
+          logger.w("Failed on ${board.version}: $e");
+          continue;
+        }
       }
     }
 
     if (!boardConnected) {
       connected = false;
-      throw Exception(
-          "Failed to open. See warnings above for the exact reason.");
+      throw Exception("Failed to open port. See warnings above.");
     }
 
     try {
@@ -145,8 +146,6 @@ class PSLabCommunicationHandler implements CommunicationHandler {
         if (readNow == 0) {
           attempts++;
           if (attempts >= 3) {
-            logger.w(
-                "No signal on wire after retries. Returning $numBytesRead bytes.");
             return numBytesRead;
           }
           await Future.delayed(const Duration(milliseconds: 50));

--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -9,6 +10,7 @@ import 'package:pslab/providers/locator.dart';
 import 'package:pslab/providers/settings_config_provider.dart';
 import 'package:pslab/others/science_lab_common.dart';
 import 'package:pslab/communication/handler/wifi_comms_handler.dart';
+import 'package:pslab/communication/handler/comms_handler.dart';
 
 import 'package:pslab/src/rust/api/simple.dart' as rust_api;
 
@@ -47,11 +49,21 @@ class BoardStateProvider extends ChangeNotifier {
   Future<void> initialize() async {
     if (_isProcessing) return;
     _isProcessing = true;
+
     if (!scienceLabCommon.isConnected()) {
       await scienceLabCommon.initialize();
-      bool portOpened = await scienceLabCommon.openDevice();
-      if (portOpened) {
-        await _validateHandshake();
+
+      if (!kIsWeb &&
+          (Platform.isWindows || Platform.isMacOS || Platform.isLinux)) {
+        bool success = await _connectToDesktopDynamic();
+        if (!success) {
+          logger.w("PSLab not found on any available COM port.");
+        }
+      } else {
+        bool portOpened = await scienceLabCommon.openDevice();
+        if (portOpened) {
+          await _validateHandshake();
+        }
       }
     }
     _isProcessing = false;
@@ -76,6 +88,48 @@ class BoardStateProvider extends ChangeNotifier {
         _resetConnectionState();
       }
     });
+  }
+
+  Future<bool> _connectToDesktopDynamic() async {
+    if (ScienceLabCommon.communicationHandler is! PSLabCommunicationHandler)
+      return false;
+
+    final comms =
+        ScienceLabCommon.communicationHandler as PSLabCommunicationHandler;
+    List<String> ports = rust_api.getAvailablePorts();
+
+    for (String port in ports) {
+      try {
+        logger.d("Testing port $port for PSLab handshake...");
+        comms.targetPortName = port;
+        bool portOpened = await scienceLabCommon.openDevice();
+
+        if (portOpened) {
+          await setPSLabVersionIDs();
+
+          if (pslabVersionID == pslabVersionIDV6 ||
+              pslabVersionID == pslabVersionIDV5) {
+            logger.i("Found PSLab on $port!");
+            pslabIsConnected = true;
+            await fetchFirmwareVersion();
+            notifyListeners();
+            return true;
+          } else {
+            logger.w(
+                "Device on $port failed handshake. Closing and moving to next port...");
+            comms.close();
+            _resetConnectionState();
+          }
+        }
+      } catch (e) {
+        logger.w("Exception while testing $port: $e");
+        comms.close();
+        _resetConnectionState();
+      }
+    }
+
+    comms.targetPortName = null;
+    return false;
   }
 
   void _startDesktopMonitor() {
@@ -106,9 +160,14 @@ class BoardStateProvider extends ChangeNotifier {
 
       try {
         if (!scienceLabCommon.isConnected() && await attemptToConnectPSLab()) {
-          bool portOpened = await scienceLabCommon.openDevice();
-          if (portOpened) {
-            await _validateHandshake();
+          if (!kIsWeb &&
+              (Platform.isWindows || Platform.isMacOS || Platform.isLinux)) {
+            await _connectToDesktopDynamic();
+          } else {
+            bool portOpened = await scienceLabCommon.openDevice();
+            if (portOpened) {
+              await _validateHandshake();
+            }
           }
         }
       } catch (e) {

--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -91,8 +91,9 @@ class BoardStateProvider extends ChangeNotifier {
   }
 
   Future<bool> _connectToDesktopDynamic() async {
-    if (ScienceLabCommon.communicationHandler is! PSLabCommunicationHandler)
+    if (ScienceLabCommon.communicationHandler is! PSLabCommunicationHandler) {
       return false;
+    }
 
     final comms =
         ScienceLabCommon.communicationHandler as PSLabCommunicationHandler;

--- a/lib/src/rust/api/simple.dart
+++ b/lib/src/rust/api/simple.dart
@@ -12,6 +12,12 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 Future<void> initDesktop({required int vid, required int pid}) =>
     RustLib.instance.api.crateApiSimpleInitDesktop(vid: vid, pid: pid);
 
+List<String> getAvailablePorts() =>
+    RustLib.instance.api.crateApiSimpleGetAvailablePorts();
+
+Future<void> initDesktopByPort({required String portName}) =>
+    RustLib.instance.api.crateApiSimpleInitDesktopByPort(portName: portName);
+
 Future<void> initAndroid({required int fd}) =>
     RustLib.instance.api.crateApiSimpleInitAndroid(fd: fd);
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -69,7 +69,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 214360270;
+  int get rustContentHash => 279082254;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -87,9 +87,13 @@ abstract class RustLibApi extends BaseApi {
 
   Stream<FlashState> crateApiBootloaderFlashFirmware({required String hexStr});
 
+  List<String> crateApiSimpleGetAvailablePorts();
+
   Future<void> crateApiSimpleInitAndroid({required int fd});
 
   Future<void> crateApiSimpleInitDesktop({required int vid, required int pid});
+
+  Future<void> crateApiSimpleInitDesktopByPort({required String portName});
 
   Uint8List crateApiSimplePopWebTxData();
 
@@ -201,13 +205,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  List<String> crateApiSimpleGetAvailablePorts() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_list_String,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiSimpleGetAvailablePortsConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiSimpleGetAvailablePortsConstMeta =>
+      const TaskConstMeta(
+        debugName: "get_available_ports",
+        argNames: [],
+      );
+
+  @override
   Future<void> crateApiSimpleInitAndroid({required int fd}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_i_32(fd, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 4, port: port_);
+            funcId: 5, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -232,7 +259,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_16(vid, serializer);
         sse_encode_u_16(pid, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 5, port: port_);
+            funcId: 6, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -250,11 +277,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void> crateApiSimpleInitDesktopByPort({required String portName}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(portName, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 7, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: sse_decode_AnyhowException,
+      ),
+      constMeta: kCrateApiSimpleInitDesktopByPortConstMeta,
+      argValues: [portName],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiSimpleInitDesktopByPortConstMeta =>
+      const TaskConstMeta(
+        debugName: "init_desktop_by_port",
+        argNames: ["portName"],
+      );
+
+  @override
   Uint8List crateApiSimplePopWebTxData() {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -277,7 +329,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_prim_u_8_loose(data, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -303,7 +355,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(bytesToRead, serializer);
         sse_encode_u_32(timeoutMs, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 8, port: port_);
+            funcId: 10, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -326,7 +378,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_32(bytesToRead, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -349,7 +401,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_32(baudRate, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -372,7 +424,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(state, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -395,7 +447,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(state, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -421,7 +473,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(host, serializer);
         sse_encode_u_16(port, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 13, port: port_);
+            funcId: 15, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -443,7 +495,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -470,7 +522,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(bytesToRead, serializer);
         sse_encode_u_32(timeoutMs, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 15, port: port_);
+            funcId: 17, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -493,7 +545,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_prim_u_8_loose(data, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -516,7 +568,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_prim_u_8_loose(data, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -587,6 +639,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as int;
+  }
+
+  @protected
+  List<String> dco_decode_list_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_String).toList();
   }
 
   @protected
@@ -684,6 +742,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<String> sse_decode_list_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <String>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_String(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var len_ = sse_decode_i_32(deserializer);
@@ -777,6 +847,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_i_32(int self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putInt32(self);
+  }
+
+  @protected
+  void sse_encode_list_String(List<String> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_String(item, serializer);
+    }
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -38,6 +38,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   int dco_decode_i_32(dynamic raw);
 
   @protected
+  List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
   List<int> dco_decode_list_prim_u_8_loose(dynamic raw);
 
   @protected
@@ -73,6 +76,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
+
+  @protected
+  List<String> sse_decode_list_String(SseDeserializer deserializer);
 
   @protected
   List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer);
@@ -111,6 +117,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_String(List<String> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_prim_u_8_loose(List<int> self, SseSerializer serializer);

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -40,6 +40,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   int dco_decode_i_32(dynamic raw);
 
   @protected
+  List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
   List<int> dco_decode_list_prim_u_8_loose(dynamic raw);
 
   @protected
@@ -75,6 +78,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
+
+  @protected
+  List<String> sse_decode_list_String(SseDeserializer deserializer);
 
   @protected
   List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer);
@@ -113,6 +119,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_String(List<String> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_prim_u_8_loose(List<int> self, SseSerializer serializer);

--- a/rust/src/api/simple.rs
+++ b/rust/src/api/simple.rs
@@ -87,6 +87,51 @@ pub fn init_desktop(vid: u16, pid: u16) -> Result<()> {
     }
 }
 
+#[frb(sync)]
+pub fn get_available_ports() -> Vec<String> {
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+    {
+        let mut port_names = Vec::new();
+        if let Ok(ports) = serialport::available_ports() {
+            for p in ports {
+                if let serialport::SerialPortType::UsbPort(info) = p.port_type {
+                    if (info.vid == 0x10C4 && info.pid == 0xEA60) || (info.vid == 1240 && info.pid == 223) {
+                        port_names.push(p.port_name);
+                    }
+                }
+            }
+        }
+        port_names
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+    {
+        vec![]
+    }
+}
+
+pub fn init_desktop_by_port(port_name: String) -> Result<()> {
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+    {
+        let mut port = serialport::new(port_name, 1_000_000)
+            .timeout(Duration::from_millis(100))
+            .open()
+            .map_err(|e| anyhow!("Failed to open Serial port: {}", e))?;
+
+        port.write_data_terminal_ready(true).unwrap_or(());
+        let _ = port.clear(serialport::ClearBuffer::All);
+
+        *SERIAL_PORT.lock().unwrap() = Some(port);
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+    {
+        let _ = port_name;
+        Err(anyhow!("Desktop USB init not supported on this platform"))
+    }
+}
+
 pub fn init_android(fd: i32) -> Result<()> {
     #[cfg(target_os = "android")]
     {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 214360270;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 279082254;
 
 // Section: executor
 
@@ -147,6 +147,35 @@ fn wire__crate__api__bootloader__flash_firmware_impl(
         },
     )
 }
+fn wire__crate__api__simple__get_available_ports_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_available_ports",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::simple::get_available_ports())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__simple__init_android_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -211,6 +240,41 @@ fn wire__crate__api__simple__init_desktop_impl(
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
                         let output_ok = crate::api::simple::init_desktop(api_vid, api_pid)?;
+                        Ok(output_ok)
+                    })(),
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__simple__init_desktop_by_port_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "init_desktop_by_port",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_port_name = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || {
+                        let output_ok = crate::api::simple::init_desktop_by_port(api_port_name)?;
                         Ok(output_ok)
                     })(),
                 )
@@ -690,6 +754,18 @@ impl SseDecode for i32 {
     }
 }
 
+impl SseDecode for Vec<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<String>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<u8> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -738,11 +814,12 @@ fn pde_ffi_dispatcher_primary_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         3 => wire__crate__api__bootloader__flash_firmware_impl(port, ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__simple__init_android_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__simple__init_desktop_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__simple__read_data_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__simple__wifi_connect_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__simple__wifi_read_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__simple__init_android_impl(port, ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__simple__init_desktop_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__simple__init_desktop_by_port_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__simple__read_data_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__simple__wifi_connect_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__simple__wifi_read_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -759,15 +836,16 @@ fn pde_ffi_dispatcher_sync_impl(
             wire__crate__api__simple__check_desktop_device_present_impl(ptr, rust_vec_len, data_len)
         }
         2 => wire__crate__api__simple__close_usb_impl(ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__simple__pop_web_tx_data_impl(ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__simple__push_web_data_impl(ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__simple__read_web_data_impl(ptr, rust_vec_len, data_len),
-        10 => wire__crate__api__simple__set_baud_rate_impl(ptr, rust_vec_len, data_len),
-        11 => wire__crate__api__simple__set_dtr_impl(ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__simple__set_rts_impl(ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__simple__wifi_disconnect_impl(ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__simple__wifi_write_impl(ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__simple__write_data_impl(ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__simple__get_available_ports_impl(ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__simple__pop_web_tx_data_impl(ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__simple__push_web_data_impl(ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__simple__read_web_data_impl(ptr, rust_vec_len, data_len),
+        12 => wire__crate__api__simple__set_baud_rate_impl(ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__simple__set_dtr_impl(ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__simple__set_rts_impl(ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__simple__wifi_disconnect_impl(ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__simple__wifi_write_impl(ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__simple__write_data_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -871,6 +949,16 @@ impl SseEncode for i32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_i32::<NativeEndian>(self).unwrap();
+    }
+}
+
+impl SseEncode for Vec<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <String>::sse_encode(item, serializer);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #3519

## Changes

Previously, the device connection function checked only the first available COM port. If another COM device, such as an ESP32, was connected, the function could fail to complete the handshake process with the intended device. As a result, the device was not connected, and the function did not proceed to check the other available ports.

Now, the function checks **all available COM ports** and verifies the handshake on each port. Once a matching handshake is detected, the function connects to the correct device successfully.

## Screenshots / Recordings

https://github.com/user-attachments/assets/11c92b35-4a25-4026-acfb-34cd8be81997

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Enable PSLab discovery across all candidate desktop COM ports instead of relying on a single device connection attempt.

New Features:
- Add desktop COM-port discovery and port-specific initialization for PSLab connections.

Bug Fixes:
- Detect and connect to PSLab reliably when multiple USB serial devices are connected by validating the handshake across available ports.

Enhancements:
- Preserve platform-specific connection behavior while adding dynamic desktop connection attempts and cleanup between failed handshakes.

Chores:
- Regenerate Flutter Rust Bridge bindings for the new serial-port APIs.