### PR TITLE
fix: add file access entitlement for macOS

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -18,5 +18,7 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -14,5 +14,7 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #3513

## Changes
Added the required macOS file access entitlement.

## Screenshots / Recordings
Before:

https://github.com/user-attachments/assets/cb777353-9558-4260-8329-5a8fa95931fa

After:

https://github.com/user-attachments/assets/cb497ace-f64b-4b4b-ac1b-09997797628b



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Enable the required macOS file access entitlement in debug, profile, and release builds.