### PR TITLE
fix: Add semantic labels to Oscilloscope tab buttons for screen readers

### DIFF
--- a/lib/view/widgets/oscilloscope_screen_tabs.dart
+++ b/lib/view/widgets/oscilloscope_screen_tabs.dart
@@ -143,6 +143,7 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                 excludeSemantics: true,
                 selected: oscilloscopeStateProvider.selectedIndex == 0,
                 label: appLocalizations.channels,
+                onTap: () => _selectTab(oscilloscopeStateProvider, 0),
                 child: GestureDetector(
                   onTap: () => _selectTab(oscilloscopeStateProvider, 0),
                   child: Column(
@@ -199,6 +200,7 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                 excludeSemantics: true,
                 selected: oscilloscopeStateProvider.selectedIndex == 1,
                 label: appLocalizations.timeBase,
+                onTap: () => _selectTab(oscilloscopeStateProvider, 1),
                 child: GestureDetector(
                   onTap: () => _selectTab(oscilloscopeStateProvider, 1),
                   child: Column(
@@ -254,6 +256,7 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                 excludeSemantics: true,
                 selected: oscilloscopeStateProvider.selectedIndex == 2,
                 label: appLocalizations.dataAnalysis,
+                onTap: () => _selectTab(oscilloscopeStateProvider, 2),
                 child: GestureDetector(
                   onTap: () => _selectTab(oscilloscopeStateProvider, 2),
                   child: Column(
@@ -309,6 +312,7 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                 excludeSemantics: true,
                 selected: oscilloscopeStateProvider.selectedIndex == 3,
                 label: appLocalizations.xyPlot,
+                onTap: () => _selectTab(oscilloscopeStateProvider, 3),
                 child: GestureDetector(
                   onTap: () => _selectTab(oscilloscopeStateProvider, 3),
                   child: Column(

--- a/lib/view/widgets/oscilloscope_screen_tabs.dart
+++ b/lib/view/widgets/oscilloscope_screen_tabs.dart
@@ -138,84 +138,39 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
           Expanded(
             child: MouseRegion(
               cursor: SystemMouseCursors.click,
-              child: GestureDetector(
-                onTap: () => _selectTab(oscilloscopeStateProvider, 0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Expanded(
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                            vertical: 4, horizontal: 8),
-                        decoration: BoxDecoration(
-                          color: oscilloscopeTabInnerBoxColor,
-                          borderRadius: BorderRadius.circular(2),
-                          border: _tabBorder(oscilloscopeStateProvider, 0),
-                        ),
-                        margin: const EdgeInsets.all(4),
-                        child: Image.asset(
-                          widget.channelParametersImage,
-                        ),
-                      ),
-                    ),
-                    Container(
-                      margin: const EdgeInsets.symmetric(
-                          vertical: 4, horizontal: 2),
-                      color: oscilloscopeStateProvider.selectedIndex == 0
-                          ? oscilloscopeOptionTitleColor
-                          : Colors.transparent,
-                      child: Text(
-                        appLocalizations.channels,
-                        textAlign: TextAlign.center,
-                        maxLines: 1,
-                        style: TextStyle(
-                          color: oscilloscopeOptionLabelColor,
-                          fontSize: 9.5,
-                          fontStyle: FontStyle.normal,
-                          fontWeight: FontWeight.bold,
+              child: Semantics(
+                button: true,
+                excludeSemantics: true,
+                selected: oscilloscopeStateProvider.selectedIndex == 0,
+                label: appLocalizations.channels,
+                child: GestureDetector(
+                  onTap: () => _selectTab(oscilloscopeStateProvider, 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Expanded(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                              vertical: 4, horizontal: 8),
+                          decoration: BoxDecoration(
+                            color: oscilloscopeTabInnerBoxColor,
+                            borderRadius: BorderRadius.circular(2),
+                            border: _tabBorder(oscilloscopeStateProvider, 0),
+                          ),
+                          margin: const EdgeInsets.all(4),
+                          child: Image.asset(
+                            widget.channelParametersImage,
+                          ),
                         ),
                       ),
-                    ),
-                    Divider(
-                      color: oscilloscopeTabBorderColor,
-                      height: 2,
-                    )
-                  ],
-                ),
-              ),
-            ),
-          ),
-          Expanded(
-            child: MouseRegion(
-              cursor: SystemMouseCursors.click,
-              child: GestureDetector(
-                onTap: () => _selectTab(oscilloscopeStateProvider, 1),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Expanded(
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                            vertical: 4, horizontal: 8),
-                        decoration: BoxDecoration(
-                          color: oscilloscopeTabInnerBoxColor,
-                          borderRadius: BorderRadius.circular(2),
-                          border: _tabBorder(oscilloscopeStateProvider, 1),
-                        ),
-                        margin: const EdgeInsets.all(4),
-                        child: Image.asset(
-                          widget.timebaseTriggerImage,
-                        ),
-                      ),
-                    ),
-                    Container(
+                      Container(
                         margin: const EdgeInsets.symmetric(
                             vertical: 4, horizontal: 2),
-                        color: oscilloscopeStateProvider.selectedIndex == 1
+                        color: oscilloscopeStateProvider.selectedIndex == 0
                             ? oscilloscopeOptionTitleColor
                             : Colors.transparent,
                         child: Text(
-                          appLocalizations.timeBase,
+                          appLocalizations.channels,
                           textAlign: TextAlign.center,
                           maxLines: 1,
                           style: TextStyle(
@@ -224,12 +179,14 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                             fontStyle: FontStyle.normal,
                             fontWeight: FontWeight.bold,
                           ),
-                        )),
-                    Divider(
-                      color: oscilloscopeTabBorderColor,
-                      height: 2,
-                    )
-                  ],
+                        ),
+                      ),
+                      Divider(
+                        color: oscilloscopeTabBorderColor,
+                        height: 2,
+                      )
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -237,34 +194,149 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
           Expanded(
             child: MouseRegion(
               cursor: SystemMouseCursors.click,
-              child: GestureDetector(
-                onTap: () => _selectTab(oscilloscopeStateProvider, 2),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Expanded(
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                            vertical: 4, horizontal: 8),
-                        decoration: BoxDecoration(
-                          color: oscilloscopeTabInnerBoxColor,
-                          borderRadius: BorderRadius.circular(2),
-                          border: _tabBorder(oscilloscopeStateProvider, 2),
-                        ),
-                        margin: const EdgeInsets.all(4),
-                        child: Image.asset(
-                          widget.dataAnalysisImage,
+              child: Semantics(
+                button: true,
+                excludeSemantics: true,
+                selected: oscilloscopeStateProvider.selectedIndex == 1,
+                label: appLocalizations.timeBase,
+                child: GestureDetector(
+                  onTap: () => _selectTab(oscilloscopeStateProvider, 1),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Expanded(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                              vertical: 4, horizontal: 8),
+                          decoration: BoxDecoration(
+                            color: oscilloscopeTabInnerBoxColor,
+                            borderRadius: BorderRadius.circular(2),
+                            border: _tabBorder(oscilloscopeStateProvider, 1),
+                          ),
+                          margin: const EdgeInsets.all(4),
+                          child: Image.asset(
+                            widget.timebaseTriggerImage,
+                          ),
                         ),
                       ),
-                    ),
-                    Container(
+                      Container(
+                          margin: const EdgeInsets.symmetric(
+                              vertical: 4, horizontal: 2),
+                          color: oscilloscopeStateProvider.selectedIndex == 1
+                              ? oscilloscopeOptionTitleColor
+                              : Colors.transparent,
+                          child: Text(
+                            appLocalizations.timeBase,
+                            textAlign: TextAlign.center,
+                            maxLines: 1,
+                            style: TextStyle(
+                              color: oscilloscopeOptionLabelColor,
+                              fontSize: 9.5,
+                              fontStyle: FontStyle.normal,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          )),
+                      Divider(
+                        color: oscilloscopeTabBorderColor,
+                        height: 2,
+                      )
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: Semantics(
+                button: true,
+                excludeSemantics: true,
+                selected: oscilloscopeStateProvider.selectedIndex == 2,
+                label: appLocalizations.dataAnalysis,
+                child: GestureDetector(
+                  onTap: () => _selectTab(oscilloscopeStateProvider, 2),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Expanded(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                              vertical: 4, horizontal: 8),
+                          decoration: BoxDecoration(
+                            color: oscilloscopeTabInnerBoxColor,
+                            borderRadius: BorderRadius.circular(2),
+                            border: _tabBorder(oscilloscopeStateProvider, 2),
+                          ),
+                          margin: const EdgeInsets.all(4),
+                          child: Image.asset(
+                            widget.dataAnalysisImage,
+                          ),
+                        ),
+                      ),
+                      Container(
+                          margin: const EdgeInsets.symmetric(
+                              vertical: 4, horizontal: 2),
+                          color: oscilloscopeStateProvider.selectedIndex == 2
+                              ? oscilloscopeOptionTitleColor
+                              : Colors.transparent,
+                          child: Text(
+                            appLocalizations.dataAnalysis,
+                            textAlign: TextAlign.center,
+                            maxLines: 1,
+                            style: TextStyle(
+                              color: oscilloscopeOptionLabelColor,
+                              fontSize: 9.5,
+                              fontStyle: FontStyle.normal,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          )),
+                      Divider(
+                        color: oscilloscopeTabBorderColor,
+                        height: 2,
+                      )
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: Semantics(
+                button: true,
+                excludeSemantics: true,
+                selected: oscilloscopeStateProvider.selectedIndex == 3,
+                label: appLocalizations.xyPlot,
+                child: GestureDetector(
+                  onTap: () => _selectTab(oscilloscopeStateProvider, 3),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Expanded(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                              vertical: 4, horizontal: 8),
+                          decoration: BoxDecoration(
+                            color: oscilloscopeTabInnerBoxColor,
+                            borderRadius: BorderRadius.circular(2),
+                            border: _tabBorder(oscilloscopeStateProvider, 3),
+                          ),
+                          margin: const EdgeInsets.all(4),
+                          child: Image.asset(
+                            widget.xyPlotImage,
+                          ),
+                        ),
+                      ),
+                      Container(
                         margin: const EdgeInsets.symmetric(
                             vertical: 4, horizontal: 2),
-                        color: oscilloscopeStateProvider.selectedIndex == 2
+                        color: oscilloscopeStateProvider.selectedIndex == 3
                             ? oscilloscopeOptionTitleColor
                             : Colors.transparent,
                         child: Text(
-                          appLocalizations.dataAnalysis,
+                          appLocalizations.xyPlot,
                           textAlign: TextAlign.center,
                           maxLines: 1,
                           style: TextStyle(
@@ -273,58 +345,10 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                             fontStyle: FontStyle.normal,
                             fontWeight: FontWeight.bold,
                           ),
-                        )),
-                    Divider(
-                      color: oscilloscopeTabBorderColor,
-                      height: 2,
-                    )
-                  ],
-                ),
-              ),
-            ),
-          ),
-          Expanded(
-            child: MouseRegion(
-              cursor: SystemMouseCursors.click,
-              child: GestureDetector(
-                onTap: () => _selectTab(oscilloscopeStateProvider, 3),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Expanded(
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                            vertical: 4, horizontal: 8),
-                        decoration: BoxDecoration(
-                          color: oscilloscopeTabInnerBoxColor,
-                          borderRadius: BorderRadius.circular(2),
-                          border: _tabBorder(oscilloscopeStateProvider, 3),
-                        ),
-                        margin: const EdgeInsets.all(4),
-                        child: Image.asset(
-                          widget.xyPlotImage,
                         ),
                       ),
-                    ),
-                    Container(
-                      margin: const EdgeInsets.symmetric(
-                          vertical: 4, horizontal: 2),
-                      color: oscilloscopeStateProvider.selectedIndex == 3
-                          ? oscilloscopeOptionTitleColor
-                          : Colors.transparent,
-                      child: Text(
-                        appLocalizations.xyPlot,
-                        textAlign: TextAlign.center,
-                        maxLines: 1,
-                        style: TextStyle(
-                          color: oscilloscopeOptionLabelColor,
-                          fontSize: 9.5,
-                          fontStyle: FontStyle.normal,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Addresses #3348

## Changes
The Oscilloscope screen's right-side tab strip (Channels, Timebase, Data Analysis, XY Plot) used a bare `GestureDetector` wrapping an `Image.asset` and a `Text` label, with no `Semantics` node. Screen readers (TalkBack/VoiceOver) saw an unlabeled image and separate static text instead of one interactive, labeled button — exactly the pattern flagged in this issue's audit.

- `lib/view/widgets/oscilloscope_screen_tabs.dart`: wrapped each of  the 4 tabs in `Semantics(button: true, label: ..., selected: ...)` with `excludeSemantics: true` on the children, so assistive tech announces each tab as a single labeled, stateful button.

This addresses one specific pattern from #3348; the issue covers a broader accessibility audit and will need further follow-up PRs.

## Testing
- `flutter analyze` — no issues
- `flutter test` — all tests pass
- Manually verified with Windows Narrator: each tab now announces "Channels, button" / "Timebase, button" etc. instead of silent/unlabeled elements.

## Screenshots / Recordings
<!-- record enabling Windows Narrator (Win+Ctrl+Enter), then Tab/ arrow through the Oscilloscope tab strip before vs after -->

**Checklist**:
- [x] **No hard coding**: reused existing `appLocalizations` strings.
- [x] **No end of file edits**.
- [x] **Code reformatting**: ran `dart format`.
- [x] **Code analysis**: `flutter analyze` and `flutter test` pass.

## Summary by Sourcery

Bug Fixes:
- Add accessible semantic labels and button roles to all four Oscilloscope tabs so screen readers announce each tab as a single interactive control.