### PR TITLE
feat: show recording timer and duration in logged data

### DIFF
--- a/lib/others/data_service.dart
+++ b/lib/others/data_service.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:convert';
+import 'dart:math';
 import 'package:csv/csv.dart' as csv;
 import 'package:file_picker/file_picker.dart';
 import 'package:home_widget/home_widget.dart';
@@ -10,6 +11,7 @@ import 'package:intl/intl.dart';
 
 import '../l10n/app_localizations.dart';
 import '../providers/locator.dart';
+import 'recording_duration.dart';
 
 class DataService {
   AppLocalizations get appLocalizations => getIt.get<AppLocalizations>();
@@ -478,7 +480,7 @@ class DataService {
   }
 
   void writeMetaData(String instrumentName, List<List<dynamic>> data,
-      {String? extraMetadata}) {
+      {String? extraMetadata, Duration? recordingDuration}) {
     if (data.isNotEmpty && data[0].isNotEmpty && data[0][0] == instrumentName) {
       return;
     }
@@ -486,12 +488,96 @@ class DataService {
     final now = DateTime.now();
     final sdf = DateFormat('yyyy-MM-dd HH:mm:ss');
     final metaDataTime = sdf.format(now);
+    final resolvedDuration =
+        recordingDuration ?? computeRecordingDurationFromData(data);
     final metaData = <dynamic>[
       instrumentName,
       metaDataTime.split(' ')[0],
       metaDataTime.split(' ')[1],
+      if (resolvedDuration != null) resolvedDuration.inMilliseconds,
       if (extraMetadata != null) extraMetadata,
     ];
     data.insert(0, metaData);
+  }
+
+  Future<Duration?> computeRecordingDurationFromFile(File file) async {
+    try {
+      final extension = file.path.split('.').last.toLowerCase();
+      if (extension == 'json') {
+        final data = await readDataFromFile(file);
+        return computeRecordingDurationFromData(data);
+      }
+
+      final lines = await file.readAsLines();
+      if (lines.isEmpty) {
+        return null;
+      }
+
+      final codec = extension == 'txt'
+          ? csv.Csv(fieldDelimiter: '\t', dynamicTyping: true)
+          : csv.Csv(dynamicTyping: true);
+      final firstRow = codec.decode(lines.first).first;
+      final fromMeta = durationFromMetadataMilliseconds(
+        firstRow.length >= 4 ? firstRow[3] : null,
+      );
+      if (fromMeta != null) {
+        return fromMeta;
+      }
+
+      int headerIndex = -1;
+      int timestampColumn = -1;
+      double? minTimestamp;
+      double? maxTimestamp;
+
+      for (int i = 0; i < lines.length; i++) {
+        final parsed = codec.decode(lines[i]);
+        if (parsed.isEmpty) {
+          continue;
+        }
+        final row = parsed.first;
+        if (row.isEmpty) {
+          continue;
+        }
+
+        if (headerIndex < 0) {
+          for (int j = 0; j < row.length; j++) {
+            if (row[j].toString().toLowerCase() == 'timestamp') {
+              headerIndex = i;
+              timestampColumn = j;
+              break;
+            }
+          }
+          continue;
+        }
+
+        if (row.length <= timestampColumn) {
+          continue;
+        }
+        final timestamp =
+            double.tryParse(row[timestampColumn].toString());
+        if (timestamp == null) {
+          continue;
+        }
+        minTimestamp = minTimestamp == null
+            ? timestamp
+            : min(minTimestamp, timestamp);
+        maxTimestamp = maxTimestamp == null
+            ? timestamp
+            : max(maxTimestamp, timestamp);
+      }
+
+      if (minTimestamp == null || maxTimestamp == null) {
+        return null;
+      }
+
+      final deltaMs = (maxTimestamp - minTimestamp).round();
+      if (deltaMs < 0) {
+        return null;
+      }
+      return Duration(milliseconds: deltaMs);
+    } catch (e) {
+      logger.e('Error computing recording duration: $e');
+      return null;
+    }
   }
 }

--- a/lib/others/data_service.dart
+++ b/lib/others/data_service.dart
@@ -553,17 +553,14 @@ class DataService {
         if (row.length <= timestampColumn) {
           continue;
         }
-        final timestamp =
-            double.tryParse(row[timestampColumn].toString());
+        final timestamp = double.tryParse(row[timestampColumn].toString());
         if (timestamp == null) {
           continue;
         }
-        minTimestamp = minTimestamp == null
-            ? timestamp
-            : min(minTimestamp, timestamp);
-        maxTimestamp = maxTimestamp == null
-            ? timestamp
-            : max(maxTimestamp, timestamp);
+        minTimestamp =
+            minTimestamp == null ? timestamp : min(minTimestamp, timestamp);
+        maxTimestamp =
+            maxTimestamp == null ? timestamp : max(maxTimestamp, timestamp);
       }
 
       if (minTimestamp == null || maxTimestamp == null) {

--- a/lib/others/recording_duration.dart
+++ b/lib/others/recording_duration.dart
@@ -1,0 +1,95 @@
+import 'dart:math';
+
+/// Formats a recording length for display (e.g. "1 hr 2 min 3 sec").
+String formatRecordingDuration(Duration duration) {
+  final hours = duration.inHours;
+  final minutes = duration.inMinutes.remainder(60);
+  final seconds = duration.inSeconds.remainder(60);
+  final parts = <String>[];
+  if (hours > 0) {
+    parts.add('$hours hr');
+  }
+  if (minutes > 0) {
+    parts.add('$minutes min');
+  }
+  if (seconds > 0 || parts.isEmpty) {
+    parts.add('$seconds sec');
+  }
+  return parts.join(' ');
+}
+
+Duration? durationFromMetadataMilliseconds(dynamic value) {
+  final ms = int.tryParse(value.toString());
+  if (ms == null || ms < 0) {
+    return null;
+  }
+  return Duration(milliseconds: ms);
+}
+
+/// Reads duration from saved file rows (metadata row or timestamp column).
+Duration? computeRecordingDurationFromData(List<List<dynamic>> data) {
+  if (data.isEmpty) {
+    return null;
+  }
+
+  if (data[0].isNotEmpty) {
+    final fromMeta = durationFromMetadataMilliseconds(data[0].length >= 4
+        ? data[0][3]
+        : null);
+    if (fromMeta != null) {
+      return fromMeta;
+    }
+  }
+
+  int headerIndex = -1;
+  int timestampColumn = -1;
+  for (int i = 0; i < data.length; i++) {
+    final row = data[i];
+    if (row.isEmpty) {
+      continue;
+    }
+    for (int j = 0; j < row.length; j++) {
+      if (row[j].toString().toLowerCase() == 'timestamp') {
+        headerIndex = i;
+        timestampColumn = j;
+        break;
+      }
+    }
+    if (headerIndex >= 0) {
+      break;
+    }
+  }
+
+  if (headerIndex < 0 || timestampColumn < 0) {
+    return null;
+  }
+
+  double? minTimestamp;
+  double? maxTimestamp;
+  for (int i = headerIndex + 1; i < data.length; i++) {
+    final row = data[i];
+    if (row.isEmpty || row.length <= timestampColumn) {
+      continue;
+    }
+    final timestamp = double.tryParse(row[timestampColumn].toString());
+    if (timestamp == null) {
+      continue;
+    }
+    minTimestamp = minTimestamp == null
+        ? timestamp
+        : min(minTimestamp, timestamp);
+    maxTimestamp = maxTimestamp == null
+        ? timestamp
+        : max(maxTimestamp, timestamp);
+  }
+
+  if (minTimestamp == null || maxTimestamp == null) {
+    return null;
+  }
+
+  final deltaMs = (maxTimestamp - minTimestamp).round();
+  if (deltaMs < 0) {
+    return null;
+  }
+  return Duration(milliseconds: deltaMs);
+}

--- a/lib/others/recording_duration.dart
+++ b/lib/others/recording_duration.dart
@@ -33,9 +33,8 @@ Duration? computeRecordingDurationFromData(List<List<dynamic>> data) {
   }
 
   if (data[0].isNotEmpty) {
-    final fromMeta = durationFromMetadataMilliseconds(data[0].length >= 4
-        ? data[0][3]
-        : null);
+    final fromMeta = durationFromMetadataMilliseconds(
+        data[0].length >= 4 ? data[0][3] : null);
     if (fromMeta != null) {
       return fromMeta;
     }
@@ -75,12 +74,10 @@ Duration? computeRecordingDurationFromData(List<List<dynamic>> data) {
     if (timestamp == null) {
       continue;
     }
-    minTimestamp = minTimestamp == null
-        ? timestamp
-        : min(minTimestamp, timestamp);
-    maxTimestamp = maxTimestamp == null
-        ? timestamp
-        : max(maxTimestamp, timestamp);
+    minTimestamp =
+        minTimestamp == null ? timestamp : min(minTimestamp, timestamp);
+    maxTimestamp =
+        maxTimestamp == null ? timestamp : max(maxTimestamp, timestamp);
   }
 
   if (minTimestamp == null || maxTimestamp == null) {

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -25,6 +25,7 @@ import 'package:pslab/view/oled_display_screen.dart';
 
 import '../l10n/app_localizations.dart';
 import '../others/data_service.dart';
+import '../others/recording_duration.dart';
 import '../providers/locator.dart';
 import 'logged_data_chart_screen.dart';
 
@@ -47,8 +48,13 @@ class LoggedDataScreen extends StatefulWidget {
 class LoggedDataFile {
   final String instrumentName;
   final FileSystemEntity file;
+  final Duration? recordingDuration;
 
-  LoggedDataFile({required this.instrumentName, required this.file});
+  LoggedDataFile({
+    required this.instrumentName,
+    required this.file,
+    this.recordingDuration,
+  });
 }
 
 class _LoggedDataScreenState extends State<LoggedDataScreen> {
@@ -78,7 +84,16 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
     for (var name in widget.instrumentNames) {
       final files = await _dataService.getSavedFiles(name);
       for (var file in files) {
-        _allFiles.add(LoggedDataFile(instrumentName: name, file: file));
+        final duration = await _dataService.computeRecordingDurationFromFile(
+          File(file.path),
+        );
+        _allFiles.add(
+          LoggedDataFile(
+            instrumentName: name,
+            file: file,
+            recordingDuration: duration,
+          ),
+        );
       }
     }
 
@@ -648,8 +663,18 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
                         final fileName = file.uri.pathSegments.last;
                         final instrumentName =
                             _filteredFiles[index].instrumentName;
+                        final recordingDuration =
+                            _filteredFiles[index].recordingDuration;
                         final formattedDate =
                             DateFormat.yMMMd().add_jm().format(stat.modified);
+                        final durationLine = recordingDuration != null
+                            ? 'Recording: ${formatRecordingDuration(recordingDuration)}'
+                            : null;
+                        final subtitleLines = <String>[
+                          '${(stat.size / 1024).toStringAsFixed(2)} KB',
+                          if (durationLine != null) durationLine,
+                          formattedDate,
+                        ];
                         final bool selected = index == _selectedIndex;
                         return Padding(
                           padding: const EdgeInsets.symmetric(
@@ -680,8 +705,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
                                 title: Text(fileName,
                                     style: const TextStyle(
                                         fontWeight: FontWeight.bold)),
-                                subtitle: Text(
-                                    '${(stat.size / 1024).toStringAsFixed(2)} KB\n$formattedDate'),
+                                subtitle: Text(subtitleLines.join('\n')),
                                 isThreeLine: true,
                                 trailing: PopupMenuButton<String>(
                                   tooltip: appLocalizations.options,

--- a/lib/view/widgets/common_scaffold_widget.dart
+++ b/lib/view/widgets/common_scaffold_widget.dart
@@ -46,6 +46,7 @@ class CommonScaffold extends StatefulWidget {
 class _CommonScaffoldState extends State<CommonScaffold> {
   Timer? _recordingTimer;
   Duration _recordingElapsed = Duration.zero;
+  DateTime? _recordingStartedAt;
 
   @override
   void initState() {
@@ -73,10 +74,15 @@ class _CommonScaffoldState extends State<CommonScaffold> {
 
   void _startRecordingTimer() {
     _recordingElapsed = Duration.zero;
+    _recordingStartedAt = DateTime.now();
     _recordingTimer?.cancel();
     _recordingTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      final startedAt = _recordingStartedAt;
+      if (startedAt == null) {
+        return;
+      }
       setState(() {
-        _recordingElapsed += const Duration(seconds: 1);
+        _recordingElapsed = DateTime.now().difference(startedAt);
       });
     });
   }
@@ -85,6 +91,7 @@ class _CommonScaffoldState extends State<CommonScaffold> {
     _recordingTimer?.cancel();
     _recordingTimer = null;
     _recordingElapsed = Duration.zero;
+    _recordingStartedAt = null;
   }
 
   String _formatRecordingDuration(Duration duration) {

--- a/lib/view/widgets/common_scaffold_widget.dart
+++ b/lib/view/widgets/common_scaffold_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:pslab/others/light_distance_experiment.dart';
@@ -42,6 +44,85 @@ class CommonScaffold extends StatefulWidget {
 }
 
 class _CommonScaffoldState extends State<CommonScaffold> {
+  Timer? _recordingTimer;
+  Duration _recordingElapsed = Duration.zero;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.isRecording) {
+      _startRecordingTimer();
+    }
+  }
+
+  @override
+  void didUpdateWidget(CommonScaffold oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isRecording && !oldWidget.isRecording) {
+      _startRecordingTimer();
+    } else if (!widget.isRecording && oldWidget.isRecording) {
+      _stopRecordingTimer();
+    }
+  }
+
+  @override
+  void dispose() {
+    _recordingTimer?.cancel();
+    super.dispose();
+  }
+
+  void _startRecordingTimer() {
+    _recordingElapsed = Duration.zero;
+    _recordingTimer?.cancel();
+    _recordingTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      setState(() {
+        _recordingElapsed += const Duration(seconds: 1);
+      });
+    });
+  }
+
+  void _stopRecordingTimer() {
+    _recordingTimer?.cancel();
+    _recordingTimer = null;
+    _recordingElapsed = Duration.zero;
+  }
+
+  String _formatRecordingDuration(Duration duration) {
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+    if (hours > 0) {
+      return '$hours:$minutes:$seconds';
+    }
+    return '$minutes:$seconds';
+  }
+
+  Widget _buildRecordingTimer() {
+    final formatted = _formatRecordingDuration(_recordingElapsed);
+    return Padding(
+      padding: const EdgeInsets.only(right: 4),
+      child: Semantics(
+        label: '${appLocalizations.recordingStarted}: $formatted',
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.circle, color: appBarContentColor, size: 10),
+            const SizedBox(width: 6),
+            Text(
+              formatted,
+              style: TextStyle(
+                color: appBarContentColor,
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   void _setPortraitOrientation() {
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
@@ -88,6 +169,9 @@ class _CommonScaffoldState extends State<CommonScaffold> {
         );
       }
     } else {
+      if (widget.isRecording) {
+        responsiveActions.add(_buildRecordingTimer());
+      }
       if (!isVerySmall && widget.onRecordPressed != null) {
         responsiveActions.add(
           IconButton(

--- a/lib/view/widgets/export_helper.dart
+++ b/lib/view/widgets/export_helper.dart
@@ -6,6 +6,7 @@ import 'package:pslab/theme/colors.dart';
 import 'package:pslab/view/widgets/save_filename_dialog.dart';
 
 import '../../others/data_service.dart';
+import '../../others/recording_duration.dart';
 
 class ExportHelper {
   static Future<void> handleSaveData({
@@ -35,6 +36,7 @@ class ExportHelper {
         instrumentName,
         data,
         extraMetadata: extraMetadata,
+        recordingDuration: computeRecordingDurationFromData(data),
       );
 
       final file = await dataService.saveDataFile(


### PR DESCRIPTION
### Summary
Adds visible recording duration in two places:

Live timer while recording — When the user starts recording on any instrument that uses CommonScaffold, the app bar shows a dot and elapsed time (00:00, 01:23, 1:05:30) next to the stop button.
Duration in Logged Data — Each saved log lists how long the recording was (e.g. Recording: 1 min 23 sec), between file size and the saved date.
### Changes
CommonScaffold: timer starts on record, resets on stop; format MM:SS or H:MM:SS for long recordings.
recording_duration.dart: shared helpers to format duration and compute length from file data.
DataService: stores duration (ms) in file metadata on save; reads it back for old and new files.
LoggedDataScreen: shows Recording: X hr Y min Z sec per file.
ExportHelper: writes duration into metadata when saving.
### Why
Users had no feedback on how long they had been recording, and Logged Data only showed file size and date—not recording length.

### Test plan

 Open an instrument (e.g. Oscilloscope, Lux meter, Sound meter).

 Tap Record → confirm timer appears in the app bar and counts up each second.

 Tap Stop → save dialog opens; save as CSV.

 Menu → Logged Data → confirm the file shows Recording: … with correct hr/min/sec.

 Delete a single file via row ⋮ → Delete (optional sanity check).

## Summary by Sourcery

Add recording duration feedback during capture and after recordings are saved.

New Features:
- Display a live elapsed recording timer in the app bar while recordings are active.
- Show recording duration alongside file size and modification date in Logged Data.

Enhancements:
- Persist recording duration in saved file metadata and recover it from metadata or timestamp data for compatibility with existing files.
- Centralize recording-duration formatting and calculation for saved data and UI display.