### PR TITLE
fix: show dialog for analogue and digital waveform conflicts

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -950,5 +950,7 @@
     "flasherLocalFileDesc": "Select a pre-compiled .hex file from device storage.",
     "flasherBtnBrowseFile": "BROWSE FILE",
     "filterInstrument" : "Filter Instruments",
-    "allInstrument" : "All Instruments"
+    "allInstrument" : "All Instruments",
+    "hardwareLimit" : "Hardware Limitation",
+    "hardwareLimitMessage" : "Generating analog and digital waveforms simultaneously on PSLab V5/V6 may cause distortion due to shared hardware pins (SI1/SQ4, SI2/SQ3)."
 }

--- a/lib/providers/wave_generator_state_provider.dart
+++ b/lib/providers/wave_generator_state_provider.dart
@@ -72,6 +72,8 @@ class WaveGeneratorStateProvider extends ChangeNotifier {
   AudioStream? _audioStream;
 
   bool isPlayingSound = false;
+  bool isAnalogActive = false;
+  bool isDigitalActive = false;
 
   double _audioAngle = 0.0;
 
@@ -297,6 +299,7 @@ class WaveGeneratorStateProvider extends ChangeNotifier {
   Future<void> setValue(int value) async {
     if (waveGeneratorConstants.modeSelected == WaveConst.square) {
       waveGeneratorConstants.wave[selectedAnalogWave]?[propSelected!] = value;
+      isAnalogActive = true;
     } else {
       if (propSelected == WaveConst.frequency) {
         waveGeneratorConstants.wave[WaveConst.sqr1]?[propSelected!] = value;
@@ -304,6 +307,7 @@ class WaveGeneratorStateProvider extends ChangeNotifier {
         waveGeneratorConstants.wave[selectedDigitalWave]?[propSelected!] =
             value;
       }
+      isDigitalActive = true;
     }
     previewWave();
     await setWave();

--- a/lib/view/wave_generator_screen.dart
+++ b/lib/view/wave_generator_screen.dart
@@ -54,6 +54,28 @@ class _WaveGeneratorScreenState extends State<WaveGeneratorScreen> {
     });
   }
 
+  void _showHardwareConflictWarning() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text(appLocalizations.hardwareLimit),
+          content: Text(
+            appLocalizations.hardwareLimitMessage,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('OK'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   List<Widget> _getWaveGeneratorContent() {
     return [
       InstrumentIntroText(text: appLocalizations.waveGeneratorIntro),
@@ -255,7 +277,14 @@ class _WaveGeneratorScreenState extends State<WaveGeneratorScreen> {
                                           fontSize: 14,
                                         ),
                                       ),
-                                      onPressed: () => {
+                                      onPressed: () {
+                                        if (provider.isDigitalActive &&
+                                            provider.waveGeneratorConstants
+                                                    .modeSelected !=
+                                                WaveConst.square) {
+                                          _showHardwareConflictWarning();
+                                        }
+
                                         setState(
                                           () {
                                             provider.waveGeneratorConstants
@@ -264,7 +293,7 @@ class _WaveGeneratorScreenState extends State<WaveGeneratorScreen> {
                                             provider.propSelected = null;
                                             provider.previewWave();
                                           },
-                                        ),
+                                        );
                                       },
                                     ),
                                   ),
@@ -290,7 +319,14 @@ class _WaveGeneratorScreenState extends State<WaveGeneratorScreen> {
                                           fontSize: 14,
                                         ),
                                       ),
-                                      onPressed: () => {
+                                      onPressed: () {
+                                        if (provider.isAnalogActive &&
+                                            provider.waveGeneratorConstants
+                                                    .modeSelected !=
+                                                WaveConst.pwm) {
+                                          _showHardwareConflictWarning();
+                                        }
+
                                         setState(
                                           () {
                                             provider.waveGeneratorConstants
@@ -298,7 +334,7 @@ class _WaveGeneratorScreenState extends State<WaveGeneratorScreen> {
                                             provider.propSelected = null;
                                             provider.previewWave();
                                           },
-                                        ),
+                                        );
                                       },
                                     ),
                                   ),

--- a/lib/view/wave_generator_screen.dart
+++ b/lib/view/wave_generator_screen.dart
@@ -68,7 +68,7 @@ class _WaveGeneratorScreenState extends State<WaveGeneratorScreen> {
               onPressed: () {
                 Navigator.of(context).pop();
               },
-              child: const Text('OK'),
+              child: Text(appLocalizations.ok),
             ),
           ],
         );


### PR DESCRIPTION
Fixes #2470

## Changes

- Added a dialog that appears when the user attempts to generate an analogue waveform on one channel and a digital waveform on another channel, or vice versa, in a combination that is not supported by the PSLab hardware.
- The dialog informs the user about the hardware limitation and prevents them from unknowingly generating an incorrect analogue waveform.
- This makes the hardware limitation clear to the user before waveform generation begins.

## Screenshots / Recordings

https://github.com/user-attachments/assets/28513646-e22b-459f-94ce-9fd1eb935f8a


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Warn users before generating unsupported analogue and digital waveform combinations.

New Features:
- Add a localized warning dialog when users select unsupported analogue and digital waveform combinations.

Bug Fixes:
- Prevent users from unknowingly proceeding with waveform configurations that the PSLab hardware cannot support.

Enhancements:
- Track whether analogue or digital waveform output has been configured to detect conflicting selections.