### PR TITLE
fix: Add semantic labels to instrument selector cards on home screen

### DIFF
--- a/lib/view/instruments_screen.dart
+++ b/lib/view/instruments_screen.dart
@@ -226,16 +226,23 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
                             itemCount: _filteredIndices.length,
                             itemBuilder: (context, index) {
                               final int originalIndex = _filteredIndices[index];
-                              return GestureDetector(
+                              return Semantics(
+                                button: true,
+                                excludeSemantics: true,
+                                label:
+                                    '${_instrumentDatas[originalIndex].heading}. ${_instrumentDatas[originalIndex].description}',
                                 onTap: () => _onItemTapped(originalIndex),
-                                child: ApplicationsListItem(
-                                  heading: _instrumentDatas[originalIndex]
-                                      .heading
-                                      .toUpperCase(),
-                                  description: _instrumentDatas[originalIndex]
-                                      .description,
-                                  instrumentIcon:
-                                      instrumentIcons[originalIndex],
+                                child: GestureDetector(
+                                  onTap: () => _onItemTapped(originalIndex),
+                                  child: ApplicationsListItem(
+                                    heading: _instrumentDatas[originalIndex]
+                                        .heading
+                                        .toUpperCase(),
+                                    description: _instrumentDatas[originalIndex]
+                                        .description,
+                                    instrumentIcon:
+                                        instrumentIcons[originalIndex],
+                                  ),
                                 ),
                               );
                             },
@@ -249,16 +256,23 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
                             itemCount: _filteredIndices.length,
                             itemBuilder: (context, index) {
                               final int originalIndex = _filteredIndices[index];
-                              return GestureDetector(
+                              return Semantics(
+                                button: true,
+                                excludeSemantics: true,
+                                label:
+                                    '${_instrumentDatas[originalIndex].heading}. ${_instrumentDatas[originalIndex].description}',
                                 onTap: () => _onItemTapped(originalIndex),
-                                child: ApplicationsListItem(
-                                  heading: _instrumentDatas[originalIndex]
-                                      .heading
-                                      .toUpperCase(),
-                                  description: _instrumentDatas[originalIndex]
-                                      .description,
-                                  instrumentIcon:
-                                      instrumentIcons[originalIndex],
+                                child: GestureDetector(
+                                  onTap: () => _onItemTapped(originalIndex),
+                                  child: ApplicationsListItem(
+                                    heading: _instrumentDatas[originalIndex]
+                                        .heading
+                                        .toUpperCase(),
+                                    description: _instrumentDatas[originalIndex]
+                                        .description,
+                                    instrumentIcon:
+                                        instrumentIcons[originalIndex],
+                                  ),
                                 ),
                               );
                             },


### PR DESCRIPTION
Addresses #3348

## Changes
The audit in #3348 (with an annotated screenshot) flagged the main Instruments screen: each card (Oscilloscope, Multimeter, Logic Analyzer, Sensors, etc.) is built entirely from unlabeled `Image.asset` and `Text` widgets inside a bare `GestureDetector`. Screen readers saw several small, disconnected, unlabeled image nodes instead of one clearly labeled button, and the accessibility scanner reported a tap area as small as 40x40, below the 48x48dp minimum.

- `lib/view/instruments_screen.dart`: wrapped each card in `Semantics(button: true, label: '<heading>.<description>')` with  `excludeSemantics: true` on its children, merging the whole card  into one labeled semantic node sized to the full card — resolving  both the missing-label and undersized-tap-area findings at once. Applied to both the portrait `ListView.builder` and landscape `GridView.builder` code paths, covering all 16 instrument cards.

## Testing
- `flutter analyze` — no issues
- `flutter test` — all tests pass
- Manually verified with Windows Narrator: each card now announces  its full name and description as one button (e.g. "Oscilloscope. Allows observing voltages, button") instead of silent/fragmented image elements.

**Checklist**:
- [x] **No hard coding**: label built from existing localized strings.
- [x] **No end of file edits**.
- [x] **Code reformatting**: ran `dart format`.
- [x] **Code analysis**: `flutter analyze` and `flutter test` pass.

## Summary by Sourcery

Make instrument selector cards accessible by adding semantic labels and full-card button semantics across all layouts.

Bug Fixes:
- Improve instrument selector accessibility by exposing each card as a single, clearly labeled button to screen readers.
- Ensure instrument cards provide an accessible tap target covering the full card in both portrait and landscape layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for instrument items in list and grid views.
  * Instrument items are now identified as buttons with descriptive labels based on their heading and description.
  * Screen reader users can activate instrument items directly using the announced button controls.
  * Accessibility actions are supported consistently across both list and grid layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->