### PR TITLE
fix: Add text overflow handling to gyroscope and accelerometer cards

### DIFF
--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -124,14 +124,16 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
           ),
         ),
         SizedBox(width: currentToMinGap),
-        Row(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            minText,
-            SizedBox(width: minToMaxGap),
-            maxText,
-          ],
+        Flexible(
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Flexible(child: minText),
+              SizedBox(width: minToMaxGap),
+              Flexible(child: maxText),
+            ],
+          ),
         ),
       ],
     );

--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -78,12 +78,14 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
       '${appLocalizations.minValue}${minVal.toStringAsFixed(1)}',
       maxLines: 1,
       softWrap: false,
+      overflow: TextOverflow.ellipsis,
       style: minMaxStyle,
     );
     final Widget maxText = Text(
       '${appLocalizations.maxValue}${maxVal.toStringAsFixed(1)}',
       maxLines: 1,
       softWrap: false,
+      overflow: TextOverflow.ellipsis,
       style: minMaxStyle,
     );
 
@@ -487,6 +489,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                       '${widget.axis.toUpperCase()} AXIS',
                       maxLines: 1,
                       softWrap: false,
+                      overflow: TextOverflow.ellipsis,
                       style: TextStyle(
                         color: Colors.red,
                         fontWeight: FontWeight.bold,

--- a/lib/view/widgets/gyroscope_card.dart
+++ b/lib/view/widgets/gyroscope_card.dart
@@ -78,12 +78,14 @@ class _GyroscopeCardState extends State<GyroscopeCard> {
       '${appLocalizations.minValue}${minVal.toStringAsFixed(1)}',
       maxLines: 1,
       softWrap: false,
+      overflow: TextOverflow.ellipsis,
       style: minMaxStyle,
     );
     final Widget maxText = Text(
       '${appLocalizations.maxValue}${maxVal.toStringAsFixed(1)}',
       maxLines: 1,
       softWrap: false,
+      overflow: TextOverflow.ellipsis,
       style: minMaxStyle,
     );
 
@@ -492,6 +494,7 @@ class _GyroscopeCardState extends State<GyroscopeCard> {
                       '${widget.axis.toUpperCase()} AXIS',
                       maxLines: 1,
                       softWrap: false,
+                      overflow: TextOverflow.ellipsis,
                       style: TextStyle(
                         color: Colors.red,
                         fontWeight: FontWeight.bold,

--- a/lib/view/widgets/gyroscope_card.dart
+++ b/lib/view/widgets/gyroscope_card.dart
@@ -124,14 +124,16 @@ class _GyroscopeCardState extends State<GyroscopeCard> {
           ),
         ),
         SizedBox(width: currentToMinGap),
-        Row(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            minText,
-            SizedBox(width: minToMaxGap),
-            maxText,
-          ],
+        Flexible(
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Flexible(child: minText),
+              SizedBox(width: minToMaxGap),
+              Flexible(child: maxText),
+            ],
+          ),
         ),
       ],
     );


### PR DESCRIPTION
Addresses #3348

## Changes
The audit in #3348 flagged text scaling/responsive layout issues: "When the system font size is increased, some text experiences overflow/clipping, resulting in content extending beyond its allocated bounds and reducing readability."

`GyroscopeCard` and `AccelerometerCard` (used for X/Y/Z axis display on sensor screens) each had 3 `Text` widgets with `maxLines: 1` and `softWrap: false` but no `overflow` property — so text that didn't
fit was clipped abruptly instead of ellipsized. A sibling `Text` widget in the same function already correctly used `TextOverflow.ellipsis`, confirming this was a real inconsistency.

- `lib/view/widgets/gyroscope_card.dart` and `lib/view/widgets/accelerometer_card.dart`: adde  `overflow: TextOverflow.ellipsis` to the min/max value labels and  the axis title Text widgets, matching the existing correct pattern.

## Testing
- `flutter analyze` — no issues
- `flutter test` — all tests pass
- Manually verified by increasing Windows display text scaling  (Settings > Accessibility > Text size) and confirming labels now  truncate with "..." instead of clipping mid-character.

**Checklist**:
- [x] **No hard coding**: no new strings added.
- [x] **No end of file edits**.
- [x] **Code reformatting**: ran `dart format`.
- [x] **Code analysis**: `flutter analyze` and `flutter test` pass.

## Summary by Sourcery

Improve accelerometer and gyroscope cards so scaled text remains readable within the available layout.

Bug Fixes:
- Prevent sensor card labels and axis titles from clipping when text is enlarged by applying ellipsis overflow handling.

Enhancements:
- Make accelerometer and gyroscope min/max value layouts adapt to constrained widths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accelerometer and gyroscope cards by truncating long minimum, maximum, and axis-title labels with an ellipsis when space is limited.
  - Prevented text overflow in these cards for better readability across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->