### PR TITLE
feat: Add initial PSLab Mini oscilloscope support

### DIFF
--- a/lib/communication/handler/comms_handler.dart
+++ b/lib/communication/handler/comms_handler.dart
@@ -17,6 +17,7 @@ class PSLabCommunicationHandler implements CommunicationHandler {
   static const List<PSLabBoard> supportedBoards = [
     PSLabBoard(version: 'V6', vid: 0x10C4, pid: 0xEA60),
     PSLabBoard(version: 'V5', vid: 1240, pid: 223),
+    PSLabBoard(version: 'Mini', vid: 0xCAFE, pid: 0x4010),
   ];
 
   static const MethodChannel _androidChannel = MethodChannel('usb_serial');
@@ -52,10 +53,10 @@ class PSLabCommunicationHandler implements CommunicationHandler {
 
     rust_api.closeUsb();
     bool boardConnected = false;
+
     if (targetPortName != null &&
         (Platform.isWindows || Platform.isMacOS || Platform.isLinux)) {
       try {
-        logger.d("Attempting connection on specific port: $targetPortName");
         await rust_api.initDesktopByPort(portName: targetPortName!);
         boardConnected = true;
       } catch (e) {
@@ -65,11 +66,13 @@ class PSLabCommunicationHandler implements CommunicationHandler {
       for (final board in supportedBoards) {
         try {
           if (Platform.isAndroid) {
-            logger.d("Probing Android for ${board.version}...");
+            logger.d(
+                "Probing Android for ${board.version} [VID: ${board.vid}, PID: ${board.pid}]...");
             final int fd = await _androidChannel.invokeMethod('getAndroidFd', {
               "vid": board.vid,
               "pid": board.pid,
             });
+
             await rust_api.initAndroid(fd: fd);
             boardConnected = true;
             break;
@@ -79,6 +82,8 @@ class PSLabCommunicationHandler implements CommunicationHandler {
             boardConnected = true;
             break;
           }
+        } on PlatformException {
+          continue;
         } catch (e) {
           logger.w("Failed on ${board.version}: $e");
           continue;
@@ -95,10 +100,11 @@ class PSLabCommunicationHandler implements CommunicationHandler {
       rust_api.setDtr(state: true);
       rust_api.setRts(state: true);
       await Future.delayed(const Duration(milliseconds: 250));
+
       connected = true;
     } catch (e) {
       connected = false;
-      throw Exception("Failed to wake up board");
+      logger.e("Failed to wake up board: $e");
     }
   }
 
@@ -128,10 +134,10 @@ class PSLabCommunicationHandler implements CommunicationHandler {
 
   @override
   Future<int> read(Uint8List dest, int bytesToRead, int timeoutMillis) async {
-    int numBytesRead = 0;
-    int bytesToBeReadTemp = bytesToRead;
     int actualTimeout =
         (Platform.isAndroid && timeoutMillis < 500) ? 500 : timeoutMillis;
+    int numBytesRead = 0;
+    int bytesToBeReadTemp = bytesToRead;
     int attempts = 0;
 
     try {
@@ -161,12 +167,22 @@ class PSLabCommunicationHandler implements CommunicationHandler {
       logger.e("Exception during read: $e");
     }
 
+    logger.d("Successfully read $numBytesRead bytes.");
     return numBytesRead;
   }
 
   @override
   void write(Uint8List src, int timeoutMillis) {
-    if (!connected) return;
-    rust_api.writeData(data: src.toList());
+    if (!connected) {
+      logger.w("Write aborted: Device not connected.");
+      return;
+    }
+
+    try {
+      rust_api.writeData(data: src.toList());
+      logger.d("write completed successfully!");
+    } catch (e) {
+      logger.e("write failed: $e");
+    }
   }
 }

--- a/lib/communication/packet_handler.dart
+++ b/lib/communication/packet_handler.dart
@@ -24,13 +24,23 @@ class PacketHandler {
 
   Future<String> getVersion() async {
     try {
+      String scpiResponse = await queryScpi("*IDN?");
+      if (scpiResponse.contains("PSLab Pico") ||
+          scpiResponse.contains("PSLab Mini")) {
+        version = scpiResponse;
+        return version;
+      }
       sendByte(_mCommandsProto.common);
       sendByte(_mCommandsProto.getVersion);
       await _commonRead(versionStringLength + 1);
-      version = utf8.decode(_buffer).split('\n').first;
+      version = utf8
+          .decode(_buffer.sublist(0, versionStringLength + 1))
+          .split('\n')
+          .first;
     } catch (e) {
       logger.e("Error in getting version: $e");
     }
+
     return version;
   }
 
@@ -124,6 +134,9 @@ class PacketHandler {
 
   Future<int> getFirmwareVersion() async {
     try {
+      if (version.contains("Pico") || version.contains("Mini")) {
+        return 3;
+      }
       sendByte(_mCommandsProto.common);
       sendByte(_mCommandsProto.getFwVersion);
       int numBytesRead = await _commonRead(fwVersionLength);
@@ -168,5 +181,19 @@ class PacketHandler {
     if (_mCommunicationHandler.isConnected()) {
       _mCommunicationHandler.write(data, _timeout);
     }
+  }
+
+  Future<String> queryScpi(String command) async {
+    String fullCommand = "$command\r\n";
+    _mCommunicationHandler.write(
+        Uint8List.fromList(fullCommand.codeUnits), 100);
+    Uint8List buffer = Uint8List(256);
+    int bytesRead = await _mCommunicationHandler.read(buffer, 256, 500);
+    if (bytesRead > 0) {
+      String response =
+          String.fromCharCodes(buffer.sublist(0, bytesRead)).trim();
+      return response;
+    }
+    return "";
   }
 }

--- a/lib/communication/science_lab.dart
+++ b/lib/communication/science_lab.dart
@@ -60,6 +60,7 @@ class ScienceLab {
       }
     }
     if (isConnected()) {
+      await getVersion();
       await _initializeVariables();
     }
   }
@@ -72,6 +73,7 @@ class ScienceLab {
       logger.e(e);
     }
     if (isConnected()) {
+      await getVersion();
       await _initializeVariables();
     }
   }
@@ -151,14 +153,19 @@ class ScienceLab {
       dChannels.add(DigitalChannel(i));
     }
     if (isConnected()) {
-      for (String temp in ['CH1', 'CH2']) {
-        await setGain(temp, 0, true);
-      }
-      for (String temp in ['SI1', 'SI2']) {
-        await loadEquation(temp, 'sine');
+      if (!PacketHandler.version.contains("Pico") &&
+          !PacketHandler.version.contains("Mini")) {
+        for (String temp in ['CH1', 'CH2']) {
+          await setGain(temp, 0, true);
+        }
+        for (String temp in ['SI1', 'SI2']) {
+          await loadEquation(temp, 'sine');
+        }
+        await clearBuffer(0, samples);
+      } else {
+        logger.d("PSLab Pico detected: Skipping legacy binary initialization.");
       }
     }
-    await clearBuffer(0, samples);
     calibrated = false;
   }
 

--- a/lib/communication/scpi_commands.dart
+++ b/lib/communication/scpi_commands.dart
@@ -1,0 +1,3 @@
+class ScpiCommands {
+  static const String identify = "*IDN?";
+}

--- a/lib/communication/scpi_commands.dart
+++ b/lib/communication/scpi_commands.dart
@@ -1,3 +1,163 @@
 class ScpiCommands {
+  // IEEE 488.2 Common Commands
+  static const String reset = "*RST";
   static const String identify = "*IDN?";
+  static const String test = "*TST?";
+  static const String clearStatus = "*CLS";
+  static const String eventStatusEnable = "*ESE";
+  static const String eventStatusEnableQuery = "*ESE?";
+  static const String eventStatusRegisterQuery = "*ESR?";
+  static const String operationComplete = "*OPC";
+  static const String operationCompleteQuery = "*OPC?";
+  static const String serviceRequestEnable = "*SRE";
+  static const String serviceRequestEnableQuery = "*SRE?";
+  static const String statusByteQuery = "*STB?";
+  static const String wait = "*WAI";
+  static const String systemErrorNextQuery = "SYST:ERR:NEXT?";
+  static const String systemErrorCountQuery = "SYST:ERR:COUN?";
+  static const String systemVersionQuery = "SYST:VERS?";
+
+  // Communication & Transport
+  static const String commTransport = "COMM:TRAN";
+  static const String commTransportQuery = "COMM:TRAN?";
+  static const String commWifiStatusQuery = "COMM:WIFI:STAT?";
+
+  // Digital Multimeter (DMM) / DC Voltage
+  static const String measureVoltageDcQuery = "MEAS:VOLT:DC?";
+  static const String configureVoltageDc = "CONF:VOLT:DC";
+  static const String initiateVoltageDc = "INIT:VOLT:DC";
+  static const String fetchVoltageDcQuery = "FETC:VOLT:DC?";
+  static const String readVoltageDcQuery = "READ:VOLT:DC?";
+
+  // Logic Analyzer (LA)
+  static const String laConfigurePinBase = "LA:CONF:PINB";
+  static const String laConfigurePinBaseQuery = "LA:CONF:PINB?";
+  static const String laConfigurePinCount = "LA:CONF:PINC";
+  static const String laConfigurePinCountQuery = "LA:CONF:PINC?";
+  static const String laConfigureSamples = "LA:CONF:SAMP";
+  static const String laConfigureSamplesQuery = "LA:CONF:SAMP?";
+  static const String laConfigureDivider = "LA:CONF:DIV";
+  static const String laConfigureDividerQuery = "LA:CONF:DIV?";
+  static const String laConfigureRateQuery = "LA:CONF:RATE?";
+
+  static const String laConfigureTriggerPin = "LA:CONF:TRIG:PIN";
+  static const String laConfigureTriggerPinQuery = "LA:CONF:TRIG:PIN?";
+  static const String laConfigureTriggerLevel = "LA:CONF:TRIG:LEV";
+  static const String laConfigureTriggerLevelQuery = "LA:CONF:TRIG:LEV?";
+  static const String laConfigureTriggerMode = "LA:CONF:TRIG:MODE";
+  static const String laConfigureTriggerModeQuery = "LA:CONF:TRIG:MODE?";
+
+  static const String laInitiate = "LA:INIT";
+  static const String laFetchDataQuery = "LA:FETC?";
+  static const String laReadQuery = "LA:READ?";
+  static const String laStatusQuery = "LA:STAT?";
+  static const String laMetadataQuery = "LA:MET?";
+
+  static const String laStreamStart = "LA:STREAM:STAR";
+  static const String laStreamStop = "LA:STREAM:STOP";
+  static const String laStreamStatusQuery = "LA:STREAM:STAT?";
+  static const String laWifiReadQuery = "LA:WIFI:READ?";
+
+  // Oscilloscope (DSO)
+  static const String dsoConfigureChannel = "DSO:CONF:CHAN";
+  static const String dsoConfigureChannelQuery = "DSO:CONF:CHAN?";
+  static const String dsoConfigureGpioQuery = "DSO:CONF:GPIO?";
+  static const String dsoConfigureSamples = "DSO:CONF:SAMP";
+  static const String dsoConfigureSamplesQuery = "DSO:CONF:SAMP?";
+  static const String dsoConfigureRate = "DSO:CONF:RATE";
+  static const String dsoConfigureRateQuery = "DSO:CONF:RATE?";
+
+  static const String dsoConfigureTriggerLevel = "DSO:CONF:TRIG:LEV";
+  static const String dsoConfigureTriggerLevelQuery = "DSO:CONF:TRIG:LEV?";
+  static const String dsoConfigureTriggerMode = "DSO:CONF:TRIG:MODE";
+  static const String dsoConfigureTriggerModeQuery = "DSO:CONF:TRIG:MODE?";
+  static const String dsoConfigureTriggerSlope = "DSO:CONF:TRIG:SLOP";
+  static const String dsoConfigureTriggerSlopeQuery = "DSO:CONF:TRIG:SLOP?";
+
+  static const String dsoInitiate = "DSO:INIT";
+  static const String dsoFetchDataQuery = "DSO:FETC?";
+  static const String dsoReadQuery = "DSO:READ?";
+  static const String dsoStatusQuery = "DSO:STAT?";
+
+  static const String dsoStreamStart = "DSO:STREAM:STAR";
+  static const String dsoStreamStop = "DSO:STREAM:STOP";
+  static const String dsoStreamStatusQuery = "DSO:STREAM:STAT?";
+  static const String dsoWifiReadQuery = "DSO:WIFI:READ?";
+
+  // Mixed-Signal Oscilloscope (MSO)
+  static const String msoConfigureDigitalPinBase = "MSO:CONF:DIG:PINB";
+  static const String msoConfigureDigitalPinBaseQuery = "MSO:CONF:DIG:PINB?";
+  static const String msoConfigureDigitalPinCount = "MSO:CONF:DIG:PINC";
+  static const String msoConfigureDigitalPinCountQuery = "MSO:CONF:DIG:PINC?";
+  static const String msoConfigureAnalogChannel = "MSO:CONF:ANAL:CHAN";
+  static const String msoConfigureAnalogChannelQuery = "MSO:CONF:ANAL:CHAN?";
+
+  static const String msoConfigureSamples = "MSO:CONF:SAMP";
+  static const String msoConfigureSamplesQuery = "MSO:CONF:SAMP?";
+  static const String msoConfigureRate = "MSO:CONF:RATE";
+  static const String msoConfigureRateQuery = "MSO:CONF:RATE?";
+
+  static const String msoConfigureTriggerPin = "MSO:CONF:TRIG:PIN";
+  static const String msoConfigureTriggerPinQuery = "MSO:CONF:TRIG:PIN?";
+  static const String msoConfigureTriggerLevel = "MSO:CONF:TRIG:LEV";
+  static const String msoConfigureTriggerLevelQuery = "MSO:CONF:TRIG:LEV?";
+  static const String msoConfigureTriggerMode = "MSO:CONF:TRIG:MODE";
+  static const String msoConfigureTriggerModeQuery = "MSO:CONF:TRIG:MODE?";
+
+  static const String msoInitiate = "MSO:INIT";
+  static const String msoFetchDigitalQuery = "MSO:FETC:DIG?";
+  static const String msoFetchAnalogQuery = "MSO:FETC:ANAL?";
+  static const String msoReadDigitalQuery = "MSO:READ:DIG?";
+  static const String msoReadAnalogQuery = "MSO:READ:ANAL?";
+  static const String msoStatusQuery = "MSO:STAT?";
+  static const String msoMetadataQuery = "MSO:MET?";
+  static const String msoWifiReadQuery = "MSO:WIFI:READ?";
+
+  // Built-in Test Signals
+  static const String testSquare = "TEST:SQU";
+  static const String testSquareQuery = "TEST:SQU?";
+  static const String testSquareConfigure = "TEST:SQU:CONF";
+  static const String testSquarePinQuery = "TEST:SQU:PIN?";
+  static const String testSquareFrequencyQuery = "TEST:SQU:FREQ?";
+
+  static const String testAnalog = "TEST:ANAL";
+  static const String testAnalogQuery = "TEST:ANAL?";
+  static const String testAnalogConfigure = "TEST:ANAL:CONF";
+  static const String testAnalogPinQuery = "TEST:ANAL:PIN?";
+  static const String testAnalogFrequencyQuery = "TEST:ANAL:FREQ?";
+  static const String testAnalogDutyQuery = "TEST:ANAL:DUTY?";
+
+  // External Bus: I2C Gateway
+  static const String busI2cOpen = "BUS:I2C:OPEN";
+  static const String busI2cOpenQuery = "BUS:I2C:OPEN?";
+  static const String busI2cClose = "BUS:I2C:CLOS";
+  static const String busI2cConfigureBus = "BUS:I2C:CONF:BUS";
+  static const String busI2cConfigureBusQuery = "BUS:I2C:CONF:BUS?";
+  static const String busI2cConfigureRate = "BUS:I2C:CONF:RATE";
+  static const String busI2cConfigureRateQuery = "BUS:I2C:CONF:RATE?";
+  static const String busI2cConfigureAddress = "BUS:I2C:CONF:ADDR";
+  static const String busI2cConfigureAddressQuery = "BUS:I2C:CONF:ADDR?";
+  static const String busI2cConfigureTimeout = "BUS:I2C:CONF:TIME";
+  static const String busI2cConfigureTimeoutQuery = "BUS:I2C:CONF:TIME?";
+  static const String busI2cScanQuery = "BUS:I2C:SCAN?";
+  static const String busI2cWrite = "BUS:I2C:WRIT";
+  static const String busI2cReadQuery = "BUS:I2C:READ?";
+  static const String busI2cTransactQuery = "BUS:I2C:TRAN?";
+
+  // External Bus: UART Gateway
+  static const String busUartOpen = "BUS:UART:OPEN";
+  static const String busUartOpenQuery = "BUS:UART:OPEN?";
+  static const String busUartClose = "BUS:UART:CLOS";
+  static const String busUartConfigureBus = "BUS:UART:CONF:BUS";
+  static const String busUartConfigureBusQuery = "BUS:UART:CONF:BUS?";
+  static const String busUartConfigureBaud = "BUS:UART:CONF:BAUD";
+  static const String busUartConfigureBaudQuery = "BUS:UART:CONF:BAUD?";
+  static const String busUartConfigureTimeout = "BUS:UART:CONF:TIME";
+  static const String busUartConfigureTimeoutQuery = "BUS:UART:CONF:TIME?";
+  static const String busUartWrite = "BUS:UART:WRIT";
+  static const String busUartReadQuery = "BUS:UART:READ?";
+  static const String busUartAvailableQuery = "BUS:UART:AVAIL?";
+  static const String busUartClear = "BUS:UART:CLE";
+  static const String busUartFlush = "BUS:UART:FLUS";
+  static const String busUartTransactQuery = "BUS:UART:TRAN?";
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -952,5 +952,6 @@
     "filterInstrument" : "Filter Instruments",
     "allInstrument" : "All Instruments",
     "hardwareLimit" : "Hardware Limitation",
-    "hardwareLimitMessage" : "Generating analog and digital waveforms simultaneously on PSLab V5/V6 may cause distortion due to shared hardware pins (SI1/SQ4, SI2/SQ3)."
+    "hardwareLimitMessage" : "Generating analog and digital waveforms simultaneously on PSLab V5/V6 may cause distortion due to shared hardware pins (SI1/SQ4, SI2/SQ3).",
+    "pslabMini" : "PSLab Mini"
 }

--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -24,6 +24,7 @@ class BoardStateProvider extends ChangeNotifier {
   String pslabVersionID = 'Not Connected';
   String pslabVersionIDV6 = 'PSLab V6';
   String pslabVersionIDV5 = 'PSLab V5';
+  String pslabVersionIDMini = 'PSLab Pico';
   int pslabVersion = 0;
   int pslabFirmwareVersion = 0;
   bool _isProcessing = false;
@@ -107,9 +108,9 @@ class BoardStateProvider extends ChangeNotifier {
 
         if (portOpened) {
           await setPSLabVersionIDs();
-
           if (pslabVersionID == pslabVersionIDV6 ||
-              pslabVersionID == pslabVersionIDV5) {
+              pslabVersionID == pslabVersionIDV5 ||
+              pslabVersionID == pslabVersionIDMini) {
             logger.i("Found PSLab on $port!");
             pslabIsConnected = true;
             await fetchFirmwareVersion();
@@ -225,7 +226,10 @@ class BoardStateProvider extends ChangeNotifier {
   Future<void> setPSLabVersionIDs() async {
     String rawVersion = await getIt.get<ScienceLab>().getVersion();
 
-    if (rawVersion == pslabVersionIDV6) {
+    if (rawVersion.contains(pslabVersionIDMini)) {
+      pslabVersionID = pslabVersionIDMini;
+      pslabVersion = 7;
+    } else if (rawVersion == pslabVersionIDV6) {
       pslabVersionID = pslabVersionIDV6;
       pslabVersion = 6;
     } else if (rawVersion == pslabVersionIDV5) {

--- a/lib/view/connect_device_screen.dart
+++ b/lib/view/connect_device_screen.dart
@@ -95,7 +95,11 @@ class _HomeScreenState extends State<ConnectDeviceScreen> {
         builder: (context, provider, _) {
           final bool isWifiConnected =
               provider.scienceLabCommon.isWiFiConnected();
-
+          final String displayDeviceName =
+              (provider.pslabVersionID == 'PSLab Pico' ||
+                      provider.pslabVersion == 7)
+                  ? appLocalizations.pslabMini
+                  : provider.pslabVersionID;
           return SafeArea(
             child: Center(
               child: SingleChildScrollView(
@@ -124,7 +128,7 @@ class _HomeScreenState extends State<ConnectDeviceScreen> {
                                 margin:
                                     const EdgeInsets.symmetric(vertical: 20),
                                 child: Text(
-                                  '${appLocalizations.deviceConnected} via ${isWifiConnected ? "Wi-Fi" : "USB"}\n\nFirmware: ${provider.pslabVersionID}',
+                                  '${appLocalizations.deviceConnected} via ${isWifiConnected ? "Wi-Fi" : "USB"}\n\nFirmware: $displayDeviceName',
                                   textAlign: TextAlign.center,
                                   style: const TextStyle(
                                     fontSize: 18,

--- a/rust/src/api/simple.rs
+++ b/rust/src/api/simple.rs
@@ -95,9 +95,12 @@ pub fn get_available_ports() -> Vec<String> {
         if let Ok(ports) = serialport::available_ports() {
             for p in ports {
                 if let serialport::SerialPortType::UsbPort(info) = p.port_type {
-                    if (info.vid == 0x10C4 && info.pid == 0xEA60) || (info.vid == 1240 && info.pid == 223) {
-                        port_names.push(p.port_name);
-                    }
+                 if (info.vid == 0x10C4 && info.pid == 0xEA60)
+                     || (info.vid == 1240 && info.pid == 223)
+                     || (info.vid == 0xCAFE)
+                 {
+                     port_names.push(p.port_name);
+                 }
                 }
             }
         }
@@ -169,24 +172,39 @@ fn setup_device(handle: DeviceHandle<GlobalContext>) -> Result<()> {
         .map_err(|e| anyhow!("Failed to get config: {}", e))?;
 
     let is_v6_cp210x = desc.vendor_id() == 0x10C4 && desc.product_id() == 0xEA60;
-    let is_v5_mcp2200 = desc.vendor_id() == 1240 && desc.product_id() == 223;
+    // Identifies both V5 and Pico as standard CDC devices
+    let is_cdc_acm = desc.vendor_id() == 1240 || desc.vendor_id() == 0xCAFE;
 
     let mut ep_in = 0;
     let mut ep_out = 0;
-    let mut interface_num = 0;
+    let mut data_interface_num = 0;
 
+    // Safely locate and lock onto the correct Data Interface containing the Bulk endpoints
     for interface in config.interfaces() {
         for interface_desc in interface.descriptors() {
+            let mut temp_in = 0;
+            let mut temp_out = 0;
+
             for endpoint in interface_desc.endpoint_descriptors() {
                 if endpoint.transfer_type() == TransferType::Bulk {
                     if endpoint.direction() == Direction::In {
-                        ep_in = endpoint.address();
+                        temp_in = endpoint.address();
                     } else if endpoint.direction() == Direction::Out {
-                        ep_out = endpoint.address();
+                        temp_out = endpoint.address();
                     }
                 }
             }
-            interface_num = interface.number();
+
+            // If both bulk endpoints are found, lock the interface and stop searching
+            if temp_in != 0 && temp_out != 0 {
+                ep_in = temp_in;
+                ep_out = temp_out;
+                data_interface_num = interface.number();
+                break;
+            }
+        }
+        if ep_in != 0 && ep_out != 0 {
+            break;
         }
     }
 
@@ -195,31 +213,37 @@ fn setup_device(handle: DeviceHandle<GlobalContext>) -> Result<()> {
     }
 
     let _ = handle.set_auto_detach_kernel_driver(true);
+
+    // CDC ACM devices (like Pico) explicitly require Interface 0 to be claimed for control commands
+    if is_cdc_acm {
+        let _ = handle.claim_interface(0);
+    }
+
     handle
-        .claim_interface(interface_num)
-        .map_err(|e| anyhow!("Failed to claim interface: {}", e))?;
+        .claim_interface(data_interface_num)
+        .map_err(|e| anyhow!("Failed to claim data interface: {}", e))?;
 
     let timeout = Duration::from_millis(100);
 
     if is_v6_cp210x {
         let req_type = request_type(Direction::Out, RequestType::Vendor, Recipient::Device);
 
-        handle.write_control(req_type, 0x00, 0x0001, interface_num as u16, &[], timeout)?;
+        handle.write_control(req_type, 0x00, 0x0001, data_interface_num as u16, &[], timeout)?;
 
         let baud: u32 = 1_000_000;
         let baud_bytes = baud.to_le_bytes();
-        handle.write_control(req_type, 0x1E, 0, interface_num as u16, &baud_bytes, timeout)?;
+        handle.write_control(req_type, 0x1E, 0, data_interface_num as u16, &baud_bytes, timeout)?;
 
-        handle.write_control(req_type, 0x03, 0x0800, interface_num as u16, &[], timeout)?;
+        handle.write_control(req_type, 0x03, 0x0800, data_interface_num as u16, &[], timeout)?;
 
         let flow_off: [u8; 16] = [
             0x01, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x20,
             0x00, 0x00,
         ];
-        handle.write_control(req_type, 0x13, 0, interface_num as u16, &flow_off, timeout)?;
+        handle.write_control(req_type, 0x13, 0, data_interface_num as u16, &flow_off, timeout)?;
 
-        handle.write_control(req_type, 0x07, 0x0000, interface_num as u16, &[], timeout)?;
-    } else if is_v5_mcp2200 {
+        handle.write_control(req_type, 0x07, 0x0000, data_interface_num as u16, &[], timeout)?;
+    } else if is_cdc_acm {
         let req_type = request_type(Direction::Out, RequestType::Class, Recipient::Interface);
 
         let mut line_coding = vec![];
@@ -228,15 +252,16 @@ fn setup_device(handle: DeviceHandle<GlobalContext>) -> Result<()> {
         line_coding.push(0x00);
         line_coding.push(0x08);
 
-        handle.write_control(req_type, 0x20, 0, interface_num as u16, &line_coding, timeout)?;
-        handle.write_control(req_type, 0x22, 0x03, interface_num as u16, &[], timeout)?;
+        // explicitly target Interface 0 for CDC Control Commands
+        let _ = handle.write_control(req_type, 0x20, 0, 0, &line_coding, timeout);
+        let _ = handle.write_control(req_type, 0x22, 0x03, 0, &[], timeout);
     }
 
     let handle_arc = Arc::new(handle);
     *USB_HANDLE.lock().unwrap() = Some(handle_arc.clone());
     *EP_IN.lock().unwrap() = ep_in;
     *EP_OUT.lock().unwrap() = ep_out;
-    *INTERFACE_ID.lock().unwrap() = interface_num;
+    *INTERFACE_ID.lock().unwrap() = data_interface_num;
 
     *ANDROID_RUN_THREAD.lock().unwrap() = true;
     let reader_handle = handle_arc.clone();
@@ -258,7 +283,6 @@ fn setup_device(handle: DeviceHandle<GlobalContext>) -> Result<()> {
 
     Ok(())
 }
-
 #[frb(sync)]
 pub fn set_baud_rate(baud_rate: u32) -> Result<()> {
     #[cfg(target_os = "android")]
@@ -266,9 +290,9 @@ pub fn set_baud_rate(baud_rate: u32) -> Result<()> {
         if let Some(handle) = USB_HANDLE.lock().unwrap().as_ref() {
             let interface_num = *INTERFACE_ID.lock().unwrap();
             let desc = handle.device().device_descriptor().unwrap();
-            let is_v5_mcp2200 = desc.vendor_id() == 1240 && desc.product_id() == 223;
+            let is_cdc_acm = desc.vendor_id() == 1240 || desc.vendor_id() == 0x2E8A;
 
-            if is_v5_mcp2200 {
+            if is_cdc_acm {
                 let req_type = request_type(Direction::Out, RequestType::Class, Recipient::Interface);
                 let mut line_coding = vec![];
                 line_coding.extend_from_slice(&baud_rate.to_le_bytes());
@@ -313,9 +337,9 @@ pub fn set_dtr(state: bool) -> Result<()> {
         if let Some(handle) = USB_HANDLE.lock().unwrap().as_ref() {
             let interface_num = *INTERFACE_ID.lock().unwrap();
             let desc = handle.device().device_descriptor().unwrap();
-            let is_v5_mcp2200 = desc.vendor_id() == 1240;
+            let is_cdc_acm = desc.vendor_id() == 1240 || desc.vendor_id() == 0x2E8A;
 
-            if is_v5_mcp2200 {
+            if is_cdc_acm {
                 let req_type = request_type(Direction::Out, RequestType::Class, Recipient::Interface);
                 let val = if state { 0x01 } else { 0x00 };
                 let _ = handle.write_control(req_type, 0x22, val, interface_num as u16, &[], Duration::from_millis(100));
@@ -354,9 +378,9 @@ pub fn set_rts(state: bool) -> Result<()> {
         if let Some(handle) = USB_HANDLE.lock().unwrap().as_ref() {
             let interface_num = *INTERFACE_ID.lock().unwrap();
             let desc = handle.device().device_descriptor().unwrap();
-            let is_v5_mcp2200 = desc.vendor_id() == 1240;
+            let is_cdc_acm = desc.vendor_id() == 1240 || desc.vendor_id() == 0x2E8A;
 
-            if is_v5_mcp2200 {
+            if is_cdc_acm {
                 let req_type = request_type(Direction::Out, RequestType::Class, Recipient::Interface);
                 let val = if state { 0x03 } else { 0x00 };
                 let _ = handle.write_control(req_type, 0x22, val, interface_num as u16, &[], Duration::from_millis(100));
@@ -537,11 +561,12 @@ pub fn check_desktop_device_present() -> bool {
         if let Ok(ports) = serialport::available_ports() {
             for p in ports {
                 if let serialport::SerialPortType::UsbPort(info) = p.port_type {
-                    if (info.vid == 0x10C4 && info.pid == 0xEA60)
-                        || (info.vid == 1240 && info.pid == 223)
-                    {
-                        return true;
-                    }
+                 if (info.vid == 0x10C4 && info.pid == 0xEA60)
+                     || (info.vid == 1240 && info.pid == 223)
+                     || (info.vid == 0xCAFE)
+                 {
+                     return true;
+                 }
                 }
             }
         }

--- a/rust/src/api/simple.rs
+++ b/rust/src/api/simple.rs
@@ -172,14 +172,11 @@ fn setup_device(handle: DeviceHandle<GlobalContext>) -> Result<()> {
         .map_err(|e| anyhow!("Failed to get config: {}", e))?;
 
     let is_v6_cp210x = desc.vendor_id() == 0x10C4 && desc.product_id() == 0xEA60;
-    // Identifies both V5 and Pico as standard CDC devices
     let is_cdc_acm = desc.vendor_id() == 1240 || desc.vendor_id() == 0xCAFE;
 
     let mut ep_in = 0;
     let mut ep_out = 0;
     let mut data_interface_num = 0;
-
-    // Safely locate and lock onto the correct Data Interface containing the Bulk endpoints
     for interface in config.interfaces() {
         for interface_desc in interface.descriptors() {
             let mut temp_in = 0;
@@ -194,8 +191,6 @@ fn setup_device(handle: DeviceHandle<GlobalContext>) -> Result<()> {
                     }
                 }
             }
-
-            // If both bulk endpoints are found, lock the interface and stop searching
             if temp_in != 0 && temp_out != 0 {
                 ep_in = temp_in;
                 ep_out = temp_out;
@@ -213,8 +208,6 @@ fn setup_device(handle: DeviceHandle<GlobalContext>) -> Result<()> {
     }
 
     let _ = handle.set_auto_detach_kernel_driver(true);
-
-    // CDC ACM devices (like Pico) explicitly require Interface 0 to be claimed for control commands
     if is_cdc_acm {
         let _ = handle.claim_interface(0);
     }
@@ -251,8 +244,6 @@ fn setup_device(handle: DeviceHandle<GlobalContext>) -> Result<()> {
         line_coding.push(0x00);
         line_coding.push(0x00);
         line_coding.push(0x08);
-
-        // explicitly target Interface 0 for CDC Control Commands
         let _ = handle.write_control(req_type, 0x20, 0, 0, &line_coding, timeout);
         let _ = handle.write_control(req_type, 0x22, 0x03, 0, &[], timeout);
     }


### PR DESCRIPTION
Fixes #3563 #3560

## Changes

- Added **initial PSLab Mini oscilloscope support**.
- Modified the **trace capture** and **data-fetching** functions to use board-specific commands through switch statements, supporting **PSLab Mini (SCPI)** and **legacy (binary)** protocols.
- Added **SCPI query functions** to the Rust backend in `simple.rs`.
- **Verified and tested locally** using the **Pico 3.3V output pin**; the oscilloscope correctly captures the **3.3V signal**.

## Screenshots / Recordings

https://github.com/user-attachments/assets/1c50ef21-7c75-4449-877d-f263e0788951

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Add PSLab Mini oscilloscope support alongside the existing legacy board protocol.

New Features:
- Add initial oscilloscope support for PSLab Mini boards using their SCPI protocol.
- Support SCPI command definitions and binary waveform data queries through the Rust backend.

Enhancements:
- Detect board protocol at connection time and route oscilloscope capture and data retrieval between SCPI and legacy binary implementations while preserving legacy support.

Chores:
- Remove an unnecessary communication debug log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for SCPI-compatible PSLab Pico and Mini boards.
  - Boards are automatically identified and routed through the appropriate communication protocol.
  - Added SCPI command sending and binary query capabilities.
  - Trace capture and data retrieval now work with both SCPI and legacy binary boards.

- **Bug Fixes**
  - Improved firmware version detection for SCPI boards.

- **Chores**
  - Removed an internal success message from communication logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->